### PR TITLE
fix: prevent signal access after disposal in CliWatcher

### DIFF
--- a/packages/superdeck/lib/src/utils/cli_watcher.dart
+++ b/packages/superdeck/lib/src/utils/cli_watcher.dart
@@ -189,8 +189,15 @@ class CliWatcher {
 
   /// Handles process exit
   Future<void> _handleProcessExit(int exitCode) async {
+    // Check disposal flag BEFORE accessing any signals to avoid
+    // "signal read after disposed" warning when dispose() was called
+    // before this async callback executed
+    if (_disposed) {
+      return;
+    }
+
     if (_status.value == CliWatcherStatus.stopped) {
-      // Already disposed, nothing to do
+      // Already stopped via dispose(), nothing to do
       return;
     }
 


### PR DESCRIPTION
## Summary
- Fix race condition in `CliWatcher._handleProcessExit()`
- Add `_disposed` check before accessing `_status` signal

## Problem
When `dispose()` is called before the async exit handler callback executes, accessing `_status.value` causes a signal warning:
```
signal warning: [6|null] has been read after disposed
```

## Solution
Check the `_disposed` flag before accessing any signals in async callbacks.

## Test plan
- [x] All `cli_watcher_test.dart` tests pass
- [x] No signal warning appears during tests
- [x] Static analysis passes