### PR TITLE
chore: update ack dependencies 

### DIFF
--- a/melos.yaml
+++ b/melos.yaml
@@ -13,7 +13,9 @@ command:
     dependencies:
       collection: ^1.18.0
       mix: ^2.0.0-rc.0
-      ack: ^1.0.0-beta.2
+      ack: ^1.0.0-beta.4
+      ack_annotations: ^1.0.0-beta.4
+      ack_generator: ^1.0.0-beta.4
   # publish:
     # hooks:
     #   pre: melos run gen:build

--- a/packages/builder/pubspec.yaml
+++ b/packages/builder/pubspec.yaml
@@ -17,11 +17,11 @@ dependencies:
   puppeteer: ^3.17.0
   crypto: ^3.0.6
   markdown: ^7.3.0
-  ack_annotations: ^1.0.0-beta.2
+  ack_annotations: ^1.0.0-beta.4
 
 dev_dependencies:
   lints: ^5.0.0
   test: ^1.25.8
   dart_code_metrics_presets: ^2.19.0
   build_runner: ^2.5.4
-  ack_generator: ^1.0.0-beta.2
+  ack_generator: ^1.0.0-beta.4

--- a/packages/core/pubspec.yaml
+++ b/packages/core/pubspec.yaml
@@ -14,7 +14,7 @@ dependencies:
   collection: ^1.18.0
   path: ^1.9.0
   meta: ^1.15.0
-  ack: ^1.0.0-beta.2
+  ack: ^1.0.0-beta.4
   markdown: ^7.3.0
   logging: ^1.3.0
   crypto: ^3.0.6


### PR DESCRIPTION
- Update ack, ack_annotations, and ack_generator to latest beta
- Add ack_annotations and ack_generator to melos bootstrap to ensure consistent versions across all packages