### PR TITLE
Release SuperDeck v1.0.0 - First stable release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,9 @@
-### Unreleased
+## 1.0.0
 
-* Roll back experimental setext-heading hero parsing; ATX headers continue to use the shared helper.
-* Fix image hero-tag parsing to avoid inline parser overruns and keep Flutter/core paths aligned.
-* Document the shared `{.hero}` helper and scope so future contributions stay consistent.
+* First stable release of SuperDeck
+* Roll back experimental setext-heading hero parsing; ATX headers continue to use the shared helper
+* Fix image hero-tag parsing to avoid inline parser overruns and keep Flutter/core paths aligned
+* Document the shared `{.hero}` helper and scope so future contributions stay consistent
 
 ### 0.0.4
 

--- a/demo/pubspec.yaml
+++ b/demo/pubspec.yaml
@@ -11,8 +11,8 @@ dependencies:
   google_fonts: ^6.3.2
   mesh: ^0.4.3
   mix: ^2.0.0-rc.0
-  superdeck_core: ^0.0.1
-  superdeck: ^0.0.4
+  superdeck_core: ^1.0.0
+  superdeck: ^1.0.0
   signals_flutter: ^6.0.4
   naked_ui: ^0.2.0-beta.7
   remix: ^0.1.0-beta.1
@@ -23,7 +23,7 @@ dev_dependencies:
   integration_test:
     sdk: flutter
   flutter_lints: ^5.0.0
-  superdeck_cli: ^0.0.1
+  superdeck_cli: ^1.0.0
 flutter:
   uses-material-design: true
   assets:

--- a/packages/builder/CHANGELOG.md
+++ b/packages/builder/CHANGELOG.md
@@ -1,0 +1,3 @@
+## 1.0.0
+
+- First stable release of superdeck_builder

--- a/packages/builder/LICENSE
+++ b/packages/builder/LICENSE
@@ -1,0 +1,29 @@
+BSD 3-Clause License
+
+Copyright (c) 2022, Leo Farias
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this
+   list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its
+   contributors may be used to endorse or promote products derived from
+   this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/packages/builder/README.md
+++ b/packages/builder/README.md
@@ -1,0 +1,21 @@
+# superdeck_builder
+
+Build logic and asset generation for SuperDeck presentations.
+
+Most projects should use `superdeck_cli` to run builds. Use `superdeck_builder` directly when you need programmatic access to the build pipeline.
+
+## What it provides
+
+- Markdown-to-JSON slide processing
+- Asset generation pipeline (Mermaid diagrams, thumbnails)
+- Schema code generation via `build_runner`
+
+## Related packages
+
+- `superdeck` - Flutter slide runtime
+- `superdeck_core` - data models and utilities
+- `superdeck_cli` - CLI wrapper (installs the `superdeck` command)
+
+## License
+
+BSD 3-Clause. See `LICENSE`.

--- a/packages/builder/pubspec.yaml
+++ b/packages/builder/pubspec.yaml
@@ -4,7 +4,7 @@ version: 1.0.0
 homepage: https://github.com/leoafarias/superdeck
 
 environment:
-  sdk: ">=3.10.0 <4.0.0"
+  sdk: ">=3.9.0 <4.0.0"
 
 
 dependencies:

--- a/packages/builder/pubspec.yaml
+++ b/packages/builder/pubspec.yaml
@@ -1,6 +1,6 @@
 name: superdeck_builder
 description: The build logic for SuperDeck presentations
-version: 0.0.1
+version: 1.0.0
 homepage: https://github.com/leoafarias/superdeck
 
 environment:
@@ -8,7 +8,7 @@ environment:
 
 
 dependencies:
-  superdeck_core: ^0.0.1
+  superdeck_core: ^1.0.0
   logging: ^1.3.0
   path: ^1.9.0
   yaml: ^3.1.2

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.0.0
+
+- First stable release of superdeck_cli
+
 ## 0.0.1
 
 - Initial version.

--- a/packages/cli/LICENSE
+++ b/packages/cli/LICENSE
@@ -1,0 +1,29 @@
+BSD 3-Clause License
+
+Copyright (c) 2022, Leo Farias
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this
+   list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its
+   contributors may be used to endorse or promote products derived from
+   this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -130,8 +130,8 @@ superdeck publish --dry-run
 
 ## Requirements
 
-- Flutter SDK version 3.38.1 or higher
-- Dart SDK version 3.10.0 or higher
+- Dart SDK version 3.9.0 or higher
+- Flutter SDK version 3.35.0 or higher
 - Git (for publish command)
 
 ## Additional information

--- a/packages/cli/pubspec.yaml
+++ b/packages/cli/pubspec.yaml
@@ -6,7 +6,7 @@ homepage: https://github.com/leoafarias/superdeck
 executables:
   superdeck: main
 environment:
-  sdk: ">=3.10.0 <4.0.0"
+  sdk: ">=3.9.0 <4.0.0"
 
 
 dependencies:

--- a/packages/cli/pubspec.yaml
+++ b/packages/cli/pubspec.yaml
@@ -1,6 +1,6 @@
 name: superdeck_cli
 description: Command line interface for SuperDeck
-version: 0.0.1
+version: 1.0.0
 homepage: https://github.com/leoafarias/superdeck
 
 executables:
@@ -14,8 +14,8 @@ dependencies:
   args: ^2.6.0
   path: ^1.9.0
   yaml_writer: ^2.0.1
-  superdeck_core: ^0.0.1
-  superdeck_builder: ^0.0.1
+  superdeck_core: ^1.0.0
+  superdeck_builder: ^1.0.0
   mason_logger: ^0.3.1
 
 dev_dependencies:

--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -1,5 +1,6 @@
-## Unreleased
+## 1.0.0
 
+- First stable release of superdeck_core
 - Remove provisional setext hero syntax so core and Flutter stay scoped to ATX headings
 - Fix image hero parsing by delegating to the shared helper for safe marker consumption
 

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -37,4 +37,4 @@ Future<void> main() async {
 
 ## License
 
-BSD 3-Clause. See `LICENSE` in the repository root.
+BSD 3-Clause. See `LICENSE`.

--- a/packages/core/pubspec.yaml
+++ b/packages/core/pubspec.yaml
@@ -1,6 +1,6 @@
 name: superdeck_core
 description: A core library for SuperDeck.
-version: 0.0.1
+version: 1.0.0
 homepage: https://github.com/leoafarias/superdeck
 
 

--- a/packages/core/pubspec.yaml
+++ b/packages/core/pubspec.yaml
@@ -5,7 +5,7 @@ homepage: https://github.com/leoafarias/superdeck
 
 
 environment:
-  sdk: ">=3.10.0 <4.0.0"
+  sdk: ">=3.9.0 <4.0.0"
 
 
 # Add regular dependencies here.

--- a/packages/superdeck/LICENSE
+++ b/packages/superdeck/LICENSE
@@ -1,0 +1,29 @@
+BSD 3-Clause License
+
+Copyright (c) 2022, Leo Farias
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this
+   list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its
+   contributors may be used to endorse or promote products derived from
+   this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/packages/superdeck/README.md
+++ b/packages/superdeck/README.md
@@ -10,9 +10,9 @@ SuperDeck renders Markdown slides in Flutter.
 In your Flutter project:
 
 ```bash
-flutter pub add superdeck
 dart pub global activate superdeck_cli
 superdeck setup
+flutter pub add superdeck
 ```
 
 ## Initialize
@@ -73,4 +73,4 @@ https://github.com/leoafarias/superdeck/blob/main/docs/guides/custom-widgets.mdx
 
 ## License
 
-BSD 3-Clause. See `LICENSE` in the repository root.
+BSD 3-Clause. See `LICENSE`.

--- a/packages/superdeck/pubspec.yaml
+++ b/packages/superdeck/pubspec.yaml
@@ -4,8 +4,8 @@ version: 1.0.0
 homepage: https://github.com/leoafarias/superdeck
 
 environment:
-  sdk: ">=3.10.0 <4.0.0"
-  flutter: ">=3.38.1"
+  sdk: ">=3.9.0 <4.0.0"
+  flutter: ">=3.35.0"
 
 
 dependencies:

--- a/packages/superdeck/pubspec.yaml
+++ b/packages/superdeck/pubspec.yaml
@@ -1,9 +1,7 @@
 name: superdeck
-description: Presentation slides for Flutter with Flutter
-version: 0.0.4
+description: A Flutter presentation framework that renders slides written in Markdown.
+version: 1.0.0
 homepage: https://github.com/leoafarias/superdeck
-
-publish_to: none
 
 environment:
   sdk: ">=3.10.0 <4.0.0"
@@ -28,7 +26,7 @@ dependencies:
   mix: ^2.0.0-rc.0
   remix: ^0.1.0-beta.2
   flutter_markdown_plus: ^1.0.5
-  superdeck_core: ^0.0.1
+  superdeck_core: ^1.0.0
   markdown: ^7.3.0
   web: ^1.1.0
   file_saver: ^0.2.14


### PR DESCRIPTION
## Summary
This release marks the first stable version of SuperDeck and all related packages, graduating from pre-release status (0.0.x) to 1.0.0.

## Key Changes

### Version Updates
- **superdeck**: 0.0.4 → 1.0.0
- **superdeck_core**: 0.0.1 → 1.0.0
- **superdeck_cli**: 0.0.1 → 1.0.0
- **superdeck_builder**: 0.0.1 → 1.0.0 (new package)

### SDK Requirements
- Relaxed minimum Dart SDK from 3.10.0 to 3.9.0 across all packages
- Relaxed minimum Flutter SDK from 3.38.1 to 3.35.0
- Updated documentation to reflect new requirements

### Package Improvements
- **superdeck**: Updated description to be more descriptive; removed `publish_to: none` restriction
- **superdeck_builder**: Added comprehensive README and LICENSE files
- **superdeck_cli**: Added LICENSE file; updated README with corrected SDK requirements
- **superdeck_core**: Updated README license reference

### Documentation & Metadata
- Added CHANGELOG entries marking first stable releases for all packages
- Added BSD 3-Clause LICENSE files to packages that were missing them
- Updated demo app dependencies to reference v1.0.0 of all SuperDeck packages
- Improved setup instructions in superdeck README (activate CLI before adding package)

### Bug Fixes & Refinements
- Finalized hero parsing implementation (rolled back experimental setext-heading syntax)
- Fixed image hero-tag parsing to prevent inline parser overruns
- Documented shared `{.hero}` helper for consistency

## Notes
All packages are now ready for public release with stable APIs and comprehensive documentation.

https://claude.ai/code/session_0146gADPUupzBvwnT92KvuwC