### PR TITLE
refactor: extract OverflowClip for hero overflow handling

### DIFF
--- a/demo/macos/Flutter/GeneratedPluginRegistrant.swift
+++ b/demo/macos/Flutter/GeneratedPluginRegistrant.swift
@@ -8,7 +8,6 @@ import Foundation
 import file_picker
 import file_saver
 import file_selector_macos
-import path_provider_foundation
 import screen_retriever_macos
 import shared_preferences_foundation
 import sqflite_darwin
@@ -20,7 +19,6 @@ func RegisterGeneratedPlugins(registry: FlutterPluginRegistry) {
   FilePickerPlugin.register(with: registry.registrar(forPlugin: "FilePickerPlugin"))
   FileSaverPlugin.register(with: registry.registrar(forPlugin: "FileSaverPlugin"))
   FileSelectorPlugin.register(with: registry.registrar(forPlugin: "FileSelectorPlugin"))
-  PathProviderPlugin.register(with: registry.registrar(forPlugin: "PathProviderPlugin"))
   ScreenRetrieverMacosPlugin.register(with: registry.registrar(forPlugin: "ScreenRetrieverMacosPlugin"))
   SharedPreferencesPlugin.register(with: registry.registrar(forPlugin: "SharedPreferencesPlugin"))
   SqflitePlugin.register(with: registry.registrar(forPlugin: "SqflitePlugin"))

--- a/packages/superdeck/lib/src/markdown/builders/code_element_builder.dart
+++ b/packages/superdeck/lib/src/markdown/builders/code_element_builder.dart
@@ -6,6 +6,7 @@ import 'package:mix/mix.dart';
 import '../../rendering/blocks/block_provider.dart';
 import '../../styling/styling.dart';
 import '../../ui/widgets/hero_element.dart';
+import '../../ui/widgets/overflow_clip.dart';
 import '../../utils/converters.dart';
 import '../../utils/syntax_highlighter.dart';
 import '../markdown_helpers.dart';
@@ -150,96 +151,90 @@ class CodeElementBuilder extends MarkdownElementBuilder with MarkdownHeroMixin {
             final fadeColor = baseColor.withValues(alpha: adjustedOpacity);
             final fadeTextStyle = fadeBaseStyle.copyWith(color: fadeColor);
 
-            // Wrap prevents overflow during hero flight when code block size changes between slides.
-            // SizedBox alone can cause RenderFlex overflow errors during interpolation.
-            return Wrap(
-              clipBehavior: Clip.hardEdge,
-              children: [
-                SizedBox.fromSize(
-                  size: interpolatedSize,
-                  child: Box(
-                    styleSpec: interpolatedSpec.container,
-                    child: Column(
-                      crossAxisAlignment: CrossAxisAlignment.start,
-                      children: () {
-                        if (highlightedLines.isEmpty) {
-                          if (fadeChar != null && fadeChar != '\n') {
-                            return [
-                              RichText(
-                                text: TextSpan(
-                                  style: interpolatedSpec.textStyle,
-                                  children: [
-                                    TextSpan(
-                                      text: fadeChar,
-                                      style: fadeTextStyle,
-                                    ),
-                                  ],
-                                ),
+            return OverflowClip(
+              child: SizedBox.fromSize(
+                size: interpolatedSize,
+                child: Box(
+                  styleSpec: interpolatedSpec.container,
+                  child: Column(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: () {
+                      if (highlightedLines.isEmpty) {
+                        if (fadeChar != null && fadeChar != '\n') {
+                          return [
+                            RichText(
+                              text: TextSpan(
+                                style: interpolatedSpec.textStyle,
+                                children: [
+                                  TextSpan(
+                                    text: fadeChar,
+                                    style: fadeTextStyle,
+                                  ),
+                                ],
                               ),
-                            ];
-                          }
-
-                          return <Widget>[];
+                            ),
+                          ];
                         }
 
-                        return List.generate(highlightedLines.length, (index) {
-                          final lineSpan = highlightedLines[index];
-                          final isLastLine =
-                              index == highlightedLines.length - 1;
-                          InlineSpan richLine;
+                        return <Widget>[];
+                      }
 
-                          if (lineSpan.children != null &&
-                              lineSpan.children!.isNotEmpty) {
-                            final children = List<InlineSpan>.from(
-                              lineSpan.children!,
+                      return List.generate(highlightedLines.length, (index) {
+                        final lineSpan = highlightedLines[index];
+                        final isLastLine = index == highlightedLines.length - 1;
+                        InlineSpan richLine;
+
+                        if (lineSpan.children != null &&
+                            lineSpan.children!.isNotEmpty) {
+                          final children = List<InlineSpan>.from(
+                            lineSpan.children!,
+                          );
+
+                          if (isLastLine &&
+                              fadeChar != null &&
+                              fadeChar != '\n') {
+                            children.add(
+                              TextSpan(text: fadeChar, style: fadeTextStyle),
                             );
-
-                            if (isLastLine &&
-                                fadeChar != null &&
-                                fadeChar != '\n') {
-                              children.add(
-                                TextSpan(text: fadeChar, style: fadeTextStyle),
-                              );
-                            }
-
-                            richLine = TextSpan(
-                              style: lineSpan.style,
-                              children: children,
-                            );
-                          } else {
-                            final children = <InlineSpan>[];
-                            if (lineSpan.text != null &&
-                                lineSpan.text!.isNotEmpty) {
-                              children.add(
-                                TextSpan(
-                                  text: lineSpan.text,
-                                  style: lineSpan.style,
-                                ),
-                              );
-                            }
-                            if (isLastLine &&
-                                fadeChar != null &&
-                                fadeChar != '\n') {
-                              children.add(
-                                TextSpan(text: fadeChar, style: fadeTextStyle),
-                              );
-                            }
-
-                            richLine = TextSpan(children: children);
                           }
 
-                          return RichText(
-                            text: TextSpan(
-                              style: interpolatedSpec.textStyle,
-                              children: [richLine],
-                            ),
+                          richLine = TextSpan(
+                            style: lineSpan.style,
+                            children: children,
                           );
-                        });
-                      }(),
-                    ),
+                        } else {
+                          final children = <InlineSpan>[];
+                          if (lineSpan.text != null &&
+                              lineSpan.text!.isNotEmpty) {
+                            children.add(
+                              TextSpan(
+                                text: lineSpan.text,
+                                style: lineSpan.style,
+                              ),
+                            );
+                          }
+                          if (isLastLine &&
+                              fadeChar != null &&
+                              fadeChar != '\n') {
+                            children.add(
+                              TextSpan(text: fadeChar, style: fadeTextStyle),
+                            );
+                          }
+
+                          richLine = TextSpan(children: children);
+                        }
+
+                        return RichText(
+                          text: TextSpan(
+                            style: interpolatedSpec.textStyle,
+                            children: [richLine],
+                          ),
+                        );
+                      });
+                    }(),
                   ),
                 ),
-              ],
+              ),
             );
           },
         );

--- a/packages/superdeck/lib/src/rendering/blocks/block_widget.dart
+++ b/packages/superdeck/lib/src/rendering/blocks/block_widget.dart
@@ -8,6 +8,7 @@ import 'package:superdeck_core/superdeck_core.dart';
 import '../../deck/slide_configuration.dart';
 import '../../styling/styling.dart';
 import '../../ui/widgets/error_widgets.dart';
+import '../../ui/widgets/overflow_clip.dart';
 import '../../ui/widgets/provider.dart';
 import '../../utils/converters.dart';
 import 'markdown_viewer.dart';
@@ -56,12 +57,10 @@ class _BlockContainerState extends State<_BlockContainer> {
       child: Box(styleSpec: spec.blockContainer, child: widget.child),
     );
 
-    // Apply scrolling or wrap (for clipping non-scrollable content)
-    final shouldScroll =
-        widget.block.scrollable && !widget.configuration.isExporting;
-    content = shouldScroll
-        ? SingleChildScrollView(child: content)
-        : Wrap(clipBehavior: Clip.hardEdge, children: [content]);
+    content = OverflowClip(
+      scrollable: widget.block.scrollable && !widget.configuration.isExporting,
+      child: content,
+    );
 
     // Apply alignment
     content = Align(

--- a/packages/superdeck/lib/src/ui/widgets/overflow_clip.dart
+++ b/packages/superdeck/lib/src/ui/widgets/overflow_clip.dart
@@ -1,0 +1,22 @@
+import 'package:flutter/widgets.dart';
+
+/// Clips overflow in a way that avoids layout assertions during size changes.
+///
+/// We intentionally use `Wrap` with `clipBehavior` for non-scrollable content
+/// instead of `ClipRect` to avoid overflow assertions in transitional layouts
+/// (for example, hero flights where size is interpolating).
+class OverflowClip extends StatelessWidget {
+  const OverflowClip({super.key, required this.child, this.scrollable = false});
+
+  final Widget child;
+  final bool scrollable;
+
+  @override
+  Widget build(BuildContext context) {
+    if (scrollable) {
+      return SingleChildScrollView(child: child);
+    }
+
+    return Wrap(clipBehavior: Clip.hardEdge, children: [child]);
+  }
+}


### PR DESCRIPTION
This refactor introduces an OverflowClip widget to centralize non-scrollable overflow clipping and optional scrolling behavior. It replaces duplicated inline Wrap(clipBehavior: Clip.hardEdge) logic in packages/superdeck/lib/src/rendering/blocks/block_widget.dart and hero flight rendering in packages/superdeck/lib/src/markdown/builders/code_element_builder.dart to keep transition-specific clipping consistent. The new widget documents why Wrap is used instead of ClipRect for transitional layouts like hero flights. The PR also includes the regenerated macOS plugin registrant update in demo/macos/Flutter/GeneratedPluginRegistrant.swift.
