### PR TITLE
Fix runtime config resolution for SuperDeckApp

### DIFF
--- a/packages/superdeck/lib/src/deck/deck_controller.dart
+++ b/packages/superdeck/lib/src/deck/deck_controller.dart
@@ -32,7 +32,6 @@ class DeckController {
   final DeckService _deckService;
   final NavigationService _navigationService;
   final ThumbnailService _thumbnailService;
-  final SlideConfigurationBuilder _slideBuilder;
   final bool _enableDeckStream;
 
   // Disposal guard to prevent accessing disposed signals
@@ -76,7 +75,10 @@ class DeckController {
   late final ReadonlySignal<List<SlideConfiguration>> slides = computed(() {
     final deck = _currentDeck.value;
     if (deck == null) return <SlideConfiguration>[];
-    return _slideBuilder.buildConfigurations(deck.slides, _options.value);
+    final configuration = _resolveDeckConfiguration(deck);
+    return SlideConfigurationBuilder(
+      configuration: configuration,
+    ).buildConfigurations(deck.slides, _options.value);
   });
 
   late final ReadonlySignal<int> totalSlides = computed(
@@ -127,10 +129,7 @@ class DeckController {
   }) : _deckService = deckService,
        _navigationService = navigationService ?? NavigationService(),
        _thumbnailService = thumbnailService ?? ThumbnailService(),
-       _enableDeckStream = enableDeckStream,
-       _slideBuilder = SlideConfigurationBuilder(
-         configuration: deckService.configuration,
-       ) {
+       _enableDeckStream = enableDeckStream {
     _options.value = options;
 
     // Create router with index change callback
@@ -156,6 +155,14 @@ class DeckController {
   // ========================================
   // DECK OPERATIONS
   // ========================================
+
+  DeckConfiguration _resolveDeckConfiguration(Deck deck) {
+    final deckConfiguration = deck.configuration;
+    if (deckConfiguration == DeckConfiguration()) {
+      return _deckService.configuration;
+    }
+    return deckConfiguration;
+  }
 
   void _startDeckStream() {
     _loadingState.value = DeckLoadingState.loading;

--- a/packages/superdeck/lib/src/deck/deck_controller.dart
+++ b/packages/superdeck/lib/src/deck/deck_controller.dart
@@ -158,10 +158,16 @@ class DeckController {
 
   DeckConfiguration _resolveDeckConfiguration(Deck deck) {
     final deckConfiguration = deck.configuration;
-    if (deckConfiguration == DeckConfiguration()) {
-      return _deckService.configuration;
-    }
-    return deckConfiguration;
+    return _hasExplicitConfigurationOverrides(deckConfiguration)
+        ? deckConfiguration
+        : _deckService.configuration;
+  }
+
+  bool _hasExplicitConfigurationOverrides(DeckConfiguration configuration) {
+    return configuration.projectDir != null ||
+        configuration.slidesPath != null ||
+        configuration.outputDir != null ||
+        configuration.assetsPath != null;
   }
 
   void _startDeckStream() {

--- a/packages/superdeck/lib/src/deck/deck_controller_builder.dart
+++ b/packages/superdeck/lib/src/deck/deck_controller_builder.dart
@@ -7,6 +7,7 @@ import 'package:superdeck_core/superdeck_core.dart';
 
 import '../ui/widgets/provider.dart';
 import '../utils/cli_watcher.dart';
+import '../utils/config_resolver.dart';
 import '../utils/constants.dart';
 import 'bundled_deck_service.dart';
 import 'deck_controller.dart';
@@ -18,11 +19,13 @@ import 'deck_options.dart';
 /// including CLI watcher integration for auto-rebuild functionality.
 class DeckControllerBuilder extends StatefulWidget {
   final DeckOptions options;
+  final DeckConfiguration? configuration;
   final Widget Function(BuildContext context, GoRouter router) builder;
 
   const DeckControllerBuilder({
     super.key,
     required this.options,
+    this.configuration,
     required this.builder,
   });
 
@@ -40,7 +43,7 @@ class _DeckControllerBuilderState extends State<DeckControllerBuilder> {
   void initState() {
     super.initState();
 
-    final configuration = DeckConfiguration();
+    final configuration = resolveConfiguration(widget.configuration);
     final deckService = kCanRunProcess
         ? DeckService(configuration: configuration)
         : BundledDeckService(configuration: configuration);

--- a/packages/superdeck/lib/src/ui/superdeck_app.dart
+++ b/packages/superdeck/lib/src/ui/superdeck_app.dart
@@ -1,18 +1,20 @@
 import 'package:flutter/material.dart' show MaterialApp;
+import 'package:flutter/widgets.dart';
 import 'package:mix/mix.dart';
+import 'package:superdeck_core/superdeck_core.dart';
 import 'package:superdeck/src/ui/tokens/colors.dart';
 
-import '../utils/app_initialization.dart';
-import '../deck/deck_options.dart';
 import '../deck/deck_controller_builder.dart';
+import '../deck/deck_options.dart';
+import '../utils/app_initialization.dart';
 import 'app_shell.dart';
 import 'theme.dart';
-import 'package:flutter/widgets.dart';
 
 class SuperDeckApp extends StatelessWidget {
-  const SuperDeckApp({super.key, required this.options});
+  const SuperDeckApp({super.key, required this.options, this.configuration});
 
   final DeckOptions options;
+  final DeckConfiguration? configuration;
 
   static Future<void> initialize() async {
     await initializeDependencies();
@@ -22,6 +24,7 @@ class SuperDeckApp extends StatelessWidget {
   Widget build(BuildContext context) {
     return DeckControllerBuilder(
       options: options,
+      configuration: configuration,
       builder: (context, router) {
         return MaterialApp.router(
           debugShowCheckedModeBanner: false,

--- a/packages/superdeck/lib/src/utils/config_resolver.dart
+++ b/packages/superdeck/lib/src/utils/config_resolver.dart
@@ -1,0 +1,2 @@
+export 'config_resolver_stub.dart'
+    if (dart.library.io) 'config_resolver_io.dart';

--- a/packages/superdeck/lib/src/utils/config_resolver_io.dart
+++ b/packages/superdeck/lib/src/utils/config_resolver_io.dart
@@ -1,0 +1,39 @@
+import 'package:superdeck_core/superdeck_core.dart';
+
+final _logger = Logger('ConfigResolver');
+
+DeckConfiguration resolveConfiguration(DeckConfiguration? override) {
+  if (override != null) {
+    _logger.info('Using explicit configuration override');
+    return override;
+  }
+
+  try {
+    final file = DeckConfiguration.defaultFile;
+    if (!file.existsSync()) {
+      _logger.info(
+        'Configuration file not found at ${file.path}. Using default configuration',
+      );
+      return DeckConfiguration();
+    }
+
+    final content = file.readAsStringSync();
+    final yamlMap = convertYamlToMap(content);
+    final configuration = DeckConfiguration.parse(yamlMap);
+    if (yamlMap.isEmpty) {
+      _logger.info(
+        'Configuration file at ${file.path} had no valid entries. Using default configuration',
+      );
+    } else {
+      _logger.info('Resolved configuration from ${file.path}');
+    }
+    return configuration;
+  } on Object catch (error, stackTrace) {
+    _logger.warning(
+      'Failed to resolve configuration from superdeck.yaml. Using default configuration',
+      error,
+      stackTrace,
+    );
+    return DeckConfiguration();
+  }
+}

--- a/packages/superdeck/lib/src/utils/config_resolver_stub.dart
+++ b/packages/superdeck/lib/src/utils/config_resolver_stub.dart
@@ -1,5 +1,7 @@
 import 'package:superdeck_core/superdeck_core.dart';
 
 DeckConfiguration resolveConfiguration(DeckConfiguration? override) {
+  // Web runtimes do not read local YAML files.
+  // Runtime deck configuration is loaded from bundled deck JSON.
   return override ?? DeckConfiguration();
 }

--- a/packages/superdeck/lib/src/utils/config_resolver_stub.dart
+++ b/packages/superdeck/lib/src/utils/config_resolver_stub.dart
@@ -1,0 +1,5 @@
+import 'package:superdeck_core/superdeck_core.dart';
+
+DeckConfiguration resolveConfiguration(DeckConfiguration? override) {
+  return override ?? DeckConfiguration();
+}

--- a/packages/superdeck/test/deck/deck_controller_test.dart
+++ b/packages/superdeck/test/deck/deck_controller_test.dart
@@ -14,7 +14,8 @@ class MockDeckService extends DeckService {
   Deck? _currentDeck;
   Object? _errorToEmit;
 
-  MockDeckService() : super(configuration: DeckConfiguration());
+  MockDeckService({DeckConfiguration? configuration})
+    : super(configuration: configuration ?? DeckConfiguration());
 
   @override
   Future<Deck> loadDeck() async {
@@ -257,6 +258,52 @@ void main() {
           p.join('.webdeck', 'img', 'thumbnail_web-config.png'),
         );
       });
+
+      test(
+        'falls back to service configuration when deck configuration is empty',
+        () async {
+          final serviceConfig = DeckConfiguration(
+            outputDir: '.service',
+            assetsPath: 'svc_assets',
+          );
+          final service = MockDeckService(configuration: serviceConfig);
+          final tempController = DeckController(
+            deckService: service,
+            options: const DeckOptions(),
+            enableDeckStream: true,
+          );
+
+          try {
+            final deck = createTestDeck(
+              slides: [
+                Slide(
+                  key: 'service-fallback',
+                  sections: [
+                    SectionBlock([ContentBlock('Slide')]),
+                  ],
+                ),
+              ],
+              config: DeckConfiguration(),
+            );
+            service.emitDeck(deck);
+
+            await Future.delayed(Duration.zero);
+
+            expect(tempController.slides.value, hasLength(1));
+            expect(
+              tempController.slides.value.first.thumbnailFile,
+              p.join(
+                '.service',
+                'svc_assets',
+                'thumbnail_service-fallback.png',
+              ),
+            );
+          } finally {
+            tempController.dispose();
+            service.dispose();
+          }
+        },
+      );
     });
 
     group(

--- a/packages/superdeck/test/deck/deck_controller_test.dart
+++ b/packages/superdeck/test/deck/deck_controller_test.dart
@@ -1,6 +1,7 @@
 import 'dart:async';
 
 import 'package:flutter_test/flutter_test.dart';
+import 'package:path/path.dart' as p;
 import 'package:superdeck/src/deck/deck_controller.dart';
 import 'package:superdeck/src/deck/deck_options.dart';
 import 'package:superdeck_core/superdeck_core.dart';
@@ -230,6 +231,31 @@ void main() {
           controller.updateOptions(options);
           controller.updateOptions(options);
         }, returnsNormally);
+      });
+    });
+
+    group('Configuration Resolution', () {
+      test('uses deck configuration when building slide thumbnails', () async {
+        final deck = createTestDeck(
+          slides: [
+            Slide(
+              key: 'web-config',
+              sections: [
+                SectionBlock([ContentBlock('Slide')]),
+              ],
+            ),
+          ],
+          config: DeckConfiguration(outputDir: '.webdeck', assetsPath: 'img'),
+        );
+        mockDeckService.emitDeck(deck);
+
+        await Future.delayed(Duration.zero);
+
+        expect(controller.slides.value, hasLength(1));
+        expect(
+          controller.slides.value.first.thumbnailFile,
+          p.join('.webdeck', 'img', 'thumbnail_web-config.png'),
+        );
       });
     });
 

--- a/packages/superdeck/test/utils/config_resolver_stub_test.dart
+++ b/packages/superdeck/test/utils/config_resolver_stub_test.dart
@@ -1,0 +1,21 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:superdeck/src/utils/config_resolver_stub.dart';
+import 'package:superdeck_core/superdeck_core.dart';
+
+void main() {
+  group('resolveConfiguration (stub)', () {
+    test('returns override when provided', () {
+      final override = DeckConfiguration(slidesPath: 'override.md');
+
+      final resolved = resolveConfiguration(override);
+
+      expect(resolved, same(override));
+    });
+
+    test('returns default when no override is provided', () {
+      final resolved = resolveConfiguration(null);
+
+      expect(resolved, DeckConfiguration());
+    });
+  });
+}

--- a/packages/superdeck/test/utils/config_resolver_test.dart
+++ b/packages/superdeck/test/utils/config_resolver_test.dart
@@ -1,0 +1,97 @@
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:superdeck/src/utils/config_resolver.dart';
+import 'package:superdeck_core/superdeck_core.dart';
+
+void main() {
+  group('resolveConfiguration (io)', () {
+    late Directory originalCurrentDir;
+    late Directory tempDir;
+
+    setUp(() {
+      originalCurrentDir = Directory.current;
+      tempDir = Directory.systemTemp.createTempSync('config_resolver_test_');
+      Directory.current = tempDir;
+    });
+
+    tearDown(() {
+      Directory.current = originalCurrentDir;
+      if (tempDir.existsSync()) {
+        tempDir.deleteSync(recursive: true);
+      }
+    });
+
+    test('returns override when provided', () {
+      DeckConfiguration.defaultFile.writeAsStringSync('slidesPath: ignored.md');
+      final override = DeckConfiguration(slidesPath: 'override.md');
+
+      final resolved = resolveConfiguration(override);
+
+      expect(resolved, same(override));
+    });
+
+    test('parses a valid superdeck.yaml file', () {
+      DeckConfiguration.defaultFile.writeAsStringSync('slidesPath: custom.md');
+
+      final resolved = resolveConfiguration(null);
+
+      expect(resolved.slidesPath, 'custom.md');
+      expect(resolved.assetsPath, isNull);
+      expect(resolved.outputDir, isNull);
+      expect(resolved.projectDir, isNull);
+    });
+
+    test('falls back to default when superdeck.yaml is missing', () {
+      final resolved = resolveConfiguration(null);
+
+      expect(resolved, DeckConfiguration());
+    });
+
+    test('falls back to default when superdeck.yaml is empty', () {
+      DeckConfiguration.defaultFile.writeAsStringSync('');
+
+      final resolved = resolveConfiguration(null);
+
+      expect(resolved, DeckConfiguration());
+    });
+
+    test('falls back to default when superdeck.yaml has only comments', () {
+      DeckConfiguration.defaultFile.writeAsStringSync('# comment');
+
+      final resolved = resolveConfiguration(null);
+
+      expect(resolved, DeckConfiguration());
+    });
+
+    test('falls back to default when superdeck.yaml is malformed', () {
+      DeckConfiguration.defaultFile.writeAsStringSync(': : [invalid');
+
+      final resolved = resolveConfiguration(null);
+
+      expect(resolved, DeckConfiguration());
+    });
+
+    test(
+      'falls back to default when superdeck.yaml fails schema validation',
+      () {
+        DeckConfiguration.defaultFile.writeAsStringSync('slidesPath: 42');
+
+        final resolved = resolveConfiguration(null);
+
+        expect(resolved, DeckConfiguration());
+      },
+    );
+
+    test('parses partial fields from superdeck.yaml', () {
+      DeckConfiguration.defaultFile.writeAsStringSync('assetsPath: imgs');
+
+      final resolved = resolveConfiguration(null);
+
+      expect(resolved.assetsPath, 'imgs');
+      expect(resolved.slidesPath, isNull);
+      expect(resolved.outputDir, isNull);
+      expect(resolved.projectDir, isNull);
+    });
+  });
+}


### PR DESCRIPTION
## Summary
This PR implements runtime `DeckConfiguration` resolution with the precedence chain:
1. explicit override
2. `superdeck.yaml`
3. default fallback

It also makes web/runtime asset behavior consistent by defaulting slide/runtime path configuration to the bundled deck configuration when available.

## Changes
- Added platform-safe resolver barrel and implementations:
  - `config_resolver.dart` (conditional export)
  - `config_resolver_io.dart` (native YAML resolution + safe fallback)
  - `config_resolver_stub.dart` (web-safe fallback behavior)
- Extended `SuperDeckApp` and `DeckControllerBuilder` to accept/pass optional `DeckConfiguration`.
- Replaced hardcoded runtime config creation in `DeckControllerBuilder` with resolver-based initialization.
- Updated `DeckController` to resolve slide runtime paths from `Deck.configuration` when explicitly set, and fall back to service configuration when deck config is empty.
- Added regression tests for:
  - IO/stub resolver behavior and edge cases.
  - deck-vs-service configuration resolution behavior in `DeckController`.

## Validation
- `fvm dart analyze --fatal-infos` (package `superdeck`)
- `fvm flutter test test/utils/config_resolver_test.dart test/utils/config_resolver_stub_test.dart` (package `superdeck`)
- `fvm flutter test test/deck/deck_controller_test.dart --plain-name "Configuration Resolution"` (package `superdeck`)
- `fvm dart run melos run test`

## Notes
- Full `melos run analyze` remains blocked in this environment by unactivated DCM licensing.
