### PR TITLE
feat: add slide template system with resolver and tests

### DIFF
--- a/demo/integration_test/helpers/test_helpers.dart
+++ b/demo/integration_test/helpers/test_helpers.dart
@@ -7,6 +7,7 @@ import 'package:superdeck_example/src/parts/background.dart';
 import 'package:superdeck_example/src/parts/footer.dart';
 import 'package:superdeck_example/src/parts/header.dart';
 import 'package:superdeck_example/src/style.dart';
+import 'package:superdeck_example/src/templates.dart';
 import 'package:superdeck_example/src/widgets/demo_widgets.dart';
 
 /// Test app widget that mirrors the production app configuration.
@@ -30,6 +31,10 @@ class TestApp extends StatelessWidget {
         baseStyle: borderedStyle(),
         widgets: demoWidgets,
         styles: {'announcement': announcementStyle(), 'quote': quoteStyle()},
+        templates: {
+          'corporate': corporateTemplate(),
+          'minimal': minimalTemplate(),
+        },
         parts: const SlideParts(
           header: HeaderPart(),
           footer: FooterPart(),

--- a/demo/lib/main.dart
+++ b/demo/lib/main.dart
@@ -6,6 +6,7 @@ import 'src/parts/background.dart';
 import 'src/parts/footer.dart';
 import 'src/parts/header.dart';
 import 'src/style.dart';
+import 'src/templates.dart';
 import 'src/widgets/demo_widgets.dart';
 
 void main() async {
@@ -27,7 +28,10 @@ void main() async {
         styles: {
           'announcement': announcementStyle(),
           'quote': quoteStyle(),
-          // 'bordered': borderedStyle(),
+        },
+        templates: {
+          'corporate': corporateTemplate(),
+          'minimal': minimalTemplate(),
         },
         parts: const SlideParts(
           header: HeaderPart(),

--- a/demo/lib/src/templates.dart
+++ b/demo/lib/src/templates.dart
@@ -1,0 +1,150 @@
+import 'package:flutter/material.dart';
+import 'package:google_fonts/google_fonts.dart';
+import 'package:mix/mix.dart';
+import 'package:superdeck/superdeck.dart';
+
+/// A corporate-style template with a branded header and subtle footer.
+SlideTemplate corporateTemplate() {
+  return SlideTemplate(
+    baseStyle: SlideStyle(
+      h1: TextStyler().style(
+        TextStyleMix(
+          fontFamily: GoogleFonts.poppins().fontFamily,
+          fontSize: 64,
+          fontWeight: FontWeight.bold,
+        ),
+      ),
+      h2: TextStyler().style(
+        TextStyleMix(
+          fontFamily: GoogleFonts.poppins().fontFamily,
+          fontSize: 40,
+          fontWeight: FontWeight.w500,
+        ),
+      ),
+      p: TextStyler().style(
+        TextStyleMix(
+          fontFamily: GoogleFonts.inter().fontFamily,
+          fontSize: 24,
+        ),
+      ),
+    ),
+    styles: {
+      'highlight': SlideStyle(
+        h1: TextStyler().style(
+          TextStyleMix(
+            color: const Color(0xFF1A73E8),
+            fontSize: 72,
+            fontWeight: FontWeight.w900,
+          ),
+        ),
+        blockContainer: BoxStyler(
+          decoration: BoxDecorationMix(
+            gradient: LinearGradientMix(
+              begin: Alignment.topLeft,
+              end: Alignment.bottomRight,
+              colors: [
+                Colors.blue.shade900.withValues(alpha: 0.15),
+                Colors.transparent,
+              ],
+            ),
+          ),
+        ),
+      ),
+    },
+    parts: const SlideParts(
+      header: _CorporateHeader(),
+      footer: _CorporateFooter(),
+    ),
+  );
+}
+
+/// A minimal template with no chrome — just typography.
+SlideTemplate minimalTemplate() {
+  return SlideTemplate(
+    baseStyle: SlideStyle(
+      h1: TextStyler().style(
+        TextStyleMix(
+          fontFamily: GoogleFonts.notoSerif().fontFamily,
+          fontSize: 48,
+          fontWeight: FontWeight.w300,
+        ),
+      ),
+      p: TextStyler().style(
+        TextStyleMix(
+          fontFamily: GoogleFonts.notoSerif().fontFamily,
+          fontSize: 22,
+          height: 1.8,
+        ),
+      ),
+    ),
+  );
+}
+
+class _CorporateHeader extends StatelessWidget implements PreferredSizeWidget {
+  const _CorporateHeader();
+
+  @override
+  Size get preferredSize => const Size.fromHeight(60);
+
+  @override
+  Widget build(BuildContext context) {
+    final slide = SlideConfiguration.of(context);
+    return Padding(
+      padding: const EdgeInsets.symmetric(horizontal: 24.0),
+      child: Row(
+        children: [
+          const Icon(Icons.business, color: Color(0xFF1A73E8), size: 28),
+          const SizedBox(width: 12),
+          if (slide.options.title != null)
+            Text(
+              slide.options.title!,
+              style: GoogleFonts.poppins(
+                fontSize: 18,
+                fontWeight: FontWeight.w600,
+                color: Colors.white70,
+              ),
+            ),
+          const Spacer(),
+          Text(
+            '${slide.slideIndex + 1}',
+            style: GoogleFonts.poppins(
+              fontSize: 16,
+              color: Colors.white38,
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _CorporateFooter extends StatelessWidget implements PreferredSizeWidget {
+  const _CorporateFooter();
+
+  @override
+  Size get preferredSize => const Size.fromHeight(40);
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.symmetric(horizontal: 24.0),
+      child: Row(
+        children: [
+          Text(
+            'SuperDeck Corp',
+            style: GoogleFonts.inter(fontSize: 14, color: Colors.white30),
+          ),
+          const Spacer(),
+          Text(
+            'Confidential',
+            style: GoogleFonts.inter(
+              fontSize: 12,
+              color: Colors.white24,
+              fontStyle: FontStyle.italic,
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/demo/slides.md
+++ b/demo/slides.md
@@ -433,6 +433,48 @@ my_presentation/
 
 ---
 
+## Slide Templates {.heading}
+
+@column
+
+Templates bundle **chrome** (header, footer, background) with an **isolated style system** — like Keynote master slides.
+
+---
+template: corporate
+---
+
+@column {
+  align: center
+}
+# Corporate Template {.heading}
+
+This slide uses the `corporate` template with branded header and footer.
+
+---
+template: corporate
+style: highlight
+---
+
+@column {
+  align: center
+}
+# Highlight Style {.heading}
+
+Templates can have their own named style variants.
+
+---
+template: minimal
+---
+
+@column {
+  align: center
+}
+# Minimal Template {.heading}
+
+A clean, typography-focused template with no chrome distractions.
+
+---
+
 @section{
   align: bottom_center
   flex: 2

--- a/packages/core/lib/src/models/slide_model.dart
+++ b/packages/core/lib/src/models/slide_model.dart
@@ -140,22 +140,32 @@ class SlideOptions {
   /// The title of the slide, if any.
   final String? title;
 
-  /// The style template to apply to this slide.
+  /// The style variant to apply to this slide.
   final String? style;
 
-  /// Additional arguments passed to the slide template.
+  /// The slide template to use for chrome and style isolation.
+  final String? template;
+
+  /// Additional arguments passed to the slide.
   final Map<String, Object?> args;
 
-  const SlideOptions({this.title, this.style, this.args = const {}});
+  const SlideOptions({
+    this.title,
+    this.style,
+    this.template,
+    this.args = const {},
+  });
 
   SlideOptions copyWith({
     String? title,
     String? style,
+    String? template,
     Map<String, Object?>? args,
   }) {
     return SlideOptions(
       title: title ?? this.title,
       style: style ?? this.style,
+      template: template ?? this.template,
       args: args ?? this.args,
     );
   }
@@ -164,6 +174,7 @@ class SlideOptions {
     return {
       if (title != null) 'title': title,
       if (style != null) 'style': style,
+      if (template != null) 'template': template,
       ...args,
     };
   }
@@ -171,18 +182,26 @@ class SlideOptions {
   static SlideOptions fromMap(Map<String, dynamic> map) {
     final title = map['title'] as String?;
     final style = map['style'] as String?;
+    final template = map['template'] as String?;
 
     final args = Map<String, Object?>.from(map);
     args.remove('title');
     args.remove('style');
+    args.remove('template');
 
-    return SlideOptions(title: title, style: style, args: args);
+    return SlideOptions(
+      title: title,
+      style: style,
+      template: template,
+      args: args,
+    );
   }
 
   /// Validation schema for slide options.
   static final schema = Ack.object({
     'title': Ack.string().optional(),
     'style': Ack.string().optional(),
+    'template': Ack.string().optional(),
   }, additionalProperties: true);
 
   /// Parses slide options from a JSON map.
@@ -198,8 +217,10 @@ class SlideOptions {
           runtimeType == other.runtimeType &&
           title == other.title &&
           style == other.style &&
+          template == other.template &&
           const MapEquality().equals(args, other.args);
 
   @override
-  int get hashCode => Object.hash(title, style, const MapEquality().hash(args));
+  int get hashCode =>
+      Object.hash(title, style, template, const MapEquality().hash(args));
 }

--- a/packages/core/lib/src/models/slide_model.dart
+++ b/packages/core/lib/src/models/slide_model.dart
@@ -144,6 +144,9 @@ class SlideOptions {
   final String? style;
 
   /// The slide template to use for chrome and style isolation.
+  ///
+  /// `template: 'none'` is a reserved opt-out value used to disable template
+  /// application for the slide when a deck-level default template is configured.
   final String? template;
 
   /// Additional arguments passed to the slide.

--- a/packages/core/test/src/models/slide_model_test.dart
+++ b/packages/core/test/src/models/slide_model_test.dart
@@ -369,6 +369,20 @@ void main() {
         expect(options.args['custom'], 'value');
       });
 
+      test('creates with template parameter', () {
+        const options = SlideOptions(template: 'my-template');
+
+        expect(options.template, 'my-template');
+        expect(options.title, isNull);
+        expect(options.style, isNull);
+      });
+
+      test('template defaults to null', () {
+        const options = SlideOptions();
+
+        expect(options.template, isNull);
+      });
+
       group('copyWith', () {
         test('copies with new title', () {
           const original = SlideOptions(title: 'Original');
@@ -391,16 +405,25 @@ void main() {
           expect(copy.args, {'b': 2});
         });
 
+        test('copies with new template', () {
+          const original = SlideOptions(template: 'original-template');
+          final copy = original.copyWith(template: 'new-template');
+
+          expect(copy.template, 'new-template');
+        });
+
         test('preserves values when not specified', () {
           const original = SlideOptions(
             title: 'T',
             style: 'S',
+            template: 'tmpl',
             args: {'k': 'v'},
           );
           final copy = original.copyWith();
 
           expect(copy.title, original.title);
           expect(copy.style, original.style);
+          expect(copy.template, original.template);
           expect(copy.args, original.args);
         });
       });
@@ -420,6 +443,20 @@ void main() {
 
           expect(map['title'], 'T');
           expect(map['style'], 'S');
+        });
+
+        test('serializes template when present', () {
+          const options = SlideOptions(template: 'my-template');
+          final map = options.toMap();
+
+          expect(map['template'], 'my-template');
+        });
+
+        test('omits template when null', () {
+          const options = SlideOptions(title: 'T');
+          final map = options.toMap();
+
+          expect(map.containsKey('template'), isFalse);
         });
 
         test('spreads args into map', () {
@@ -452,6 +489,22 @@ void main() {
           expect(options.style, 'parsed-style');
         });
 
+        test('deserializes template field', () {
+          final map = {'template': 'parsed-template'};
+          final options = SlideOptions.fromMap(map);
+
+          expect(options.template, 'parsed-template');
+        });
+
+        test('removes template from args', () {
+          final map = {'template': 'tmpl', 'extra': 'val'};
+          final options = SlideOptions.fromMap(map);
+
+          expect(options.template, 'tmpl');
+          expect(options.args.containsKey('template'), isFalse);
+          expect(options.args['extra'], 'val');
+        });
+
         test('puts unknown keys into args', () {
           final map = {
             'title': 'T',
@@ -481,6 +534,18 @@ void main() {
           expect(restored.style, original.style);
           expect(restored.args['k'], original.args['k']);
         });
+
+        test('preserves template through toMap/fromMap', () {
+          const original = SlideOptions(
+            title: 'RT',
+            template: 'rt-template',
+          );
+
+          final restored = SlideOptions.fromMap(original.toMap());
+
+          expect(restored.template, original.template);
+          expect(restored.args.containsKey('template'), isFalse);
+        });
       });
 
       group('parse', () {
@@ -495,6 +560,17 @@ void main() {
 
           expect(options.title, 'T');
           expect(options.args['extra'], 'value');
+        });
+
+        test('parses map with template field', () {
+          final options = SlideOptions.parse({
+            'title': 'T',
+            'template': 'parsed-template',
+          });
+
+          expect(options.title, 'T');
+          expect(options.template, 'parsed-template');
+          expect(options.args.containsKey('template'), isFalse);
         });
       });
 
@@ -527,6 +603,20 @@ void main() {
 
           expect(opt1, isNot(opt2));
         });
+
+        test('different template makes options unequal', () {
+          const opt1 = SlideOptions(template: 'template-a');
+          const opt2 = SlideOptions(template: 'template-b');
+
+          expect(opt1, isNot(opt2));
+        });
+
+        test('template present vs absent makes options unequal', () {
+          const opt1 = SlideOptions(template: 'some-template');
+          const opt2 = SlideOptions();
+
+          expect(opt1, isNot(opt2));
+        });
       });
 
       group('schema', () {
@@ -547,6 +637,21 @@ void main() {
           final result = SlideOptions.schema.safeParse({
             'title': 'T',
             'custom': 'value',
+          });
+          expect(result.isOk, isTrue);
+        });
+
+        test('validates map with template field', () {
+          final result = SlideOptions.schema.safeParse({
+            'title': 'T',
+            'template': 'my-template',
+          });
+          expect(result.isOk, isTrue);
+        });
+
+        test('validates map with only template field', () {
+          final result = SlideOptions.schema.safeParse({
+            'template': 'standalone-template',
           });
           expect(result.isOk, isTrue);
         });

--- a/packages/superdeck/lib/src/deck/deck_options.dart
+++ b/packages/superdeck/lib/src/deck/deck_options.dart
@@ -1,5 +1,6 @@
 import '../rendering/slides/slide_parts.dart';
 import '../styling/styling.dart';
+import 'slide_template.dart';
 import 'widget_definition.dart';
 
 class DeckOptions {
@@ -8,6 +9,12 @@ class DeckOptions {
   final Map<String, WidgetDefinition> widgets;
   final SlideParts parts;
   final bool debug;
+
+  /// Named slide templates that bundle chrome + style systems.
+  final Map<String, SlideTemplate> templates;
+
+  /// Default template applied when a slide has no explicit template.
+  final SlideTemplate? defaultTemplate;
 
   /// Whether to watch for file changes and auto-rebuild the deck.
   ///
@@ -22,6 +29,8 @@ class DeckOptions {
     this.widgets = const <String, WidgetDefinition>{},
     this.parts = const SlideParts(),
     this.debug = false,
+    this.templates = const <String, SlideTemplate>{},
+    this.defaultTemplate,
     this.watchForChanges = false,
   });
 
@@ -31,6 +40,8 @@ class DeckOptions {
     Map<String, WidgetDefinition>? widgets,
     SlideParts? parts,
     bool? debug,
+    Map<String, SlideTemplate>? templates,
+    SlideTemplate? defaultTemplate,
     bool? watchForChanges,
   }) {
     return DeckOptions(
@@ -39,6 +50,8 @@ class DeckOptions {
       widgets: widgets ?? this.widgets,
       parts: parts ?? this.parts,
       debug: debug ?? this.debug,
+      templates: templates ?? this.templates,
+      defaultTemplate: defaultTemplate ?? this.defaultTemplate,
       watchForChanges: watchForChanges ?? this.watchForChanges,
     );
   }
@@ -53,9 +66,19 @@ class DeckOptions {
           widgets == other.widgets &&
           parts == other.parts &&
           debug == other.debug &&
+          templates == other.templates &&
+          defaultTemplate == other.defaultTemplate &&
           watchForChanges == other.watchForChanges;
 
   @override
-  int get hashCode =>
-      Object.hash(baseStyle, styles, widgets, parts, debug, watchForChanges);
+  int get hashCode => Object.hash(
+    baseStyle,
+    styles,
+    widgets,
+    parts,
+    debug,
+    templates,
+    defaultTemplate,
+    watchForChanges,
+  );
 }

--- a/packages/superdeck/lib/src/deck/deck_options.dart
+++ b/packages/superdeck/lib/src/deck/deck_options.dart
@@ -14,6 +14,9 @@ class DeckOptions {
   final Map<String, SlideTemplate> templates;
 
   /// Default template applied when a slide has no explicit template.
+  ///
+  /// Individual slides can opt out by setting `template: 'none'`, which
+  /// disables applying any template for that slide.
   final SlideTemplate? defaultTemplate;
 
   /// Whether to watch for file changes and auto-rebuild the deck.

--- a/packages/superdeck/lib/src/deck/slide_configuration_builder.dart
+++ b/packages/superdeck/lib/src/deck/slide_configuration_builder.dart
@@ -1,10 +1,10 @@
 import 'package:path/path.dart' as p;
 import 'package:superdeck_core/superdeck_core.dart';
 
-import '../styling/styling.dart';
 import '../widgets/widgets.dart';
 import 'deck_options.dart';
 import 'slide_configuration.dart';
+import 'template_resolver.dart';
 import 'widget_definition.dart';
 
 /// Service responsible for transforming raw Slide domain entities
@@ -28,8 +28,10 @@ class SlideConfigurationBuilder {
       return [];
     }
 
+    final resolver = TemplateResolver(options);
+
     return rawSlides.asMap().entries.map((entry) {
-      return _buildConfiguration(entry.key, entry.value, options);
+      return _buildConfiguration(entry.key, entry.value, options, resolver);
     }).toList();
   }
 
@@ -38,6 +40,7 @@ class SlideConfigurationBuilder {
     int index,
     Slide slide,
     DeckOptions options,
+    TemplateResolver resolver,
   ) {
     // Start with built-in widgets, then add user widgets that are actually used
     final widgets = Map<String, WidgetDefinition>.from(builtInWidgets);
@@ -64,18 +67,16 @@ class SlideConfigurationBuilder {
       thumbnailAsset.fileName,
     );
 
-    // Merge styles: default -> base -> slide-specific
-    final mergedStyle = defaultSlideStyle
-        .merge(options.baseStyle)
-        .merge(options.styles[slide.options?.style]);
+    // Resolve template, style, and parts
+    final resolution = resolver.resolve(slide.options);
 
     return SlideConfiguration(
       slideIndex: index,
-      style: mergedStyle,
+      style: resolution.style,
       slide: slide,
       widgets: widgets,
       thumbnailFile: thumbnailPath,
-      parts: options.parts,
+      parts: resolution.parts,
       debug: options.debug,
     );
   }

--- a/packages/superdeck/lib/src/deck/slide_template.dart
+++ b/packages/superdeck/lib/src/deck/slide_template.dart
@@ -1,0 +1,48 @@
+import '../rendering/slides/slide_parts.dart';
+import '../styling/styling.dart';
+
+/// A reusable slide template that bundles chrome (header, footer, background)
+/// with an isolated style system.
+///
+/// Templates act like Keynote master slides — providing consistent visual
+/// framing across slides without manually applying styles/parts to each slide.
+final class SlideTemplate {
+  /// Chrome parts (header, footer, background) for this template.
+  final SlideParts parts;
+
+  /// Base style applied to all slides using this template.
+  final SlideStyle? baseStyle;
+
+  /// Named style variants available within this template.
+  final Map<String, SlideStyle> styles;
+
+  const SlideTemplate({
+    this.parts = const SlideParts(),
+    this.baseStyle,
+    this.styles = const <String, SlideStyle>{},
+  });
+
+  SlideTemplate copyWith({
+    SlideParts? parts,
+    SlideStyle? baseStyle,
+    Map<String, SlideStyle>? styles,
+  }) {
+    return SlideTemplate(
+      parts: parts ?? this.parts,
+      baseStyle: baseStyle ?? this.baseStyle,
+      styles: styles ?? this.styles,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is SlideTemplate &&
+          runtimeType == other.runtimeType &&
+          parts == other.parts &&
+          baseStyle == other.baseStyle &&
+          styles == other.styles;
+
+  @override
+  int get hashCode => Object.hash(parts, baseStyle, styles);
+}

--- a/packages/superdeck/lib/src/deck/template_exception.dart
+++ b/packages/superdeck/lib/src/deck/template_exception.dart
@@ -1,0 +1,9 @@
+/// Exception thrown when template resolution fails.
+class TemplateException implements Exception {
+  final String message;
+
+  const TemplateException(this.message);
+
+  @override
+  String toString() => 'TemplateException: $message';
+}

--- a/packages/superdeck/lib/src/deck/template_resolver.dart
+++ b/packages/superdeck/lib/src/deck/template_resolver.dart
@@ -1,0 +1,135 @@
+import 'package:superdeck_core/superdeck_core.dart';
+
+import '../rendering/slides/slide_parts.dart';
+import '../styling/styling.dart';
+import 'deck_options.dart';
+import 'slide_template.dart';
+import 'template_exception.dart';
+
+/// Result of resolving a slide's template and style configuration.
+class TemplateResolutionResult {
+  /// The fully merged style for the slide.
+  final SlideStyle style;
+
+  /// The chrome parts (header, footer, background) for the slide.
+  final SlideParts parts;
+
+  /// Whether a template was used in the resolution.
+  final bool usingTemplate;
+
+  const TemplateResolutionResult({
+    required this.style,
+    required this.parts,
+    required this.usingTemplate,
+  });
+}
+
+/// Resolves slide templates and styles from [DeckOptions].
+///
+/// Resolution order:
+/// - **With template**: `defaultSlideStyle -> template.baseStyle -> template.styles[style]`
+/// - **Without template**: `defaultSlideStyle -> options.baseStyle -> options.styles[style]`
+/// - **With defaultTemplate**: applies when slide has no explicit template
+class TemplateResolver {
+  final DeckOptions _options;
+
+  const TemplateResolver(this._options);
+
+  /// Reserved template name that opts out of [DeckOptions.defaultTemplate].
+  ///
+  /// Use `template: 'none'` in slide options to fall back to deck-level
+  /// styles even when a defaultTemplate is configured.
+  static const noneTemplate = 'none';
+
+  /// Resolves the style and parts for a slide based on its options.
+  ///
+  /// Throws [TemplateException] if:
+  /// - The slide references an unknown template name
+  /// - The slide references an unknown style within a template
+  /// - The slide references an unknown deck-level style (when not using a template)
+  TemplateResolutionResult resolve(SlideOptions? slideOptions) {
+    final templateName = slideOptions?.template;
+    final styleName = slideOptions?.style;
+
+    // Determine which template to use (explicit > default > none)
+    final template = _resolveTemplate(templateName);
+
+    if (template != null) {
+      return _resolveWithTemplate(
+        template,
+        templateName ?? 'default',
+        styleName,
+      );
+    }
+
+    return _resolveWithoutTemplate(styleName);
+  }
+
+  SlideTemplate? _resolveTemplate(String? templateName) {
+    if (templateName != null) {
+      // 'none' explicitly opts out of any template
+      if (templateName == noneTemplate) return null;
+
+      final template = _options.templates[templateName];
+      if (template == null) {
+        throw TemplateException(
+          'Unknown template "$templateName". '
+          'Available templates: ${_options.templates.keys.join(', ')}',
+        );
+      }
+      return template;
+    }
+
+    return _options.defaultTemplate;
+  }
+
+  TemplateResolutionResult _resolveWithTemplate(
+    SlideTemplate template,
+    String templateName,
+    String? styleName,
+  ) {
+    SlideStyle? styleOverride;
+    if (styleName != null) {
+      styleOverride = template.styles[styleName];
+      if (styleOverride == null) {
+        throw TemplateException(
+          'Unknown style "$styleName" in template "$templateName". '
+          'Available styles: ${template.styles.keys.join(', ')}',
+        );
+      }
+    }
+
+    final mergedStyle = defaultSlideStyle
+        .merge(template.baseStyle)
+        .merge(styleOverride);
+
+    return TemplateResolutionResult(
+      style: mergedStyle,
+      parts: template.parts,
+      usingTemplate: true,
+    );
+  }
+
+  TemplateResolutionResult _resolveWithoutTemplate(String? styleName) {
+    SlideStyle? styleOverride;
+    if (styleName != null) {
+      styleOverride = _options.styles[styleName];
+      if (styleOverride == null) {
+        throw TemplateException(
+          'Unknown style "$styleName" in deck. '
+          'Available styles: ${_options.styles.keys.join(', ')}',
+        );
+      }
+    }
+
+    final mergedStyle = defaultSlideStyle
+        .merge(_options.baseStyle)
+        .merge(styleOverride);
+
+    return TemplateResolutionResult(
+      style: mergedStyle,
+      parts: _options.parts,
+      usingTemplate: false,
+    );
+  }
+}

--- a/packages/superdeck/lib/src/deck/template_resolver.dart
+++ b/packages/superdeck/lib/src/deck/template_resolver.dart
@@ -33,7 +33,16 @@ class TemplateResolutionResult {
 class TemplateResolver {
   final DeckOptions _options;
 
-  const TemplateResolver(this._options);
+  TemplateResolver(this._options) {
+    if (_options.templates.containsKey(noneTemplate)) {
+      throw ArgumentError.value(
+        noneTemplate,
+        'templates',
+        '"$noneTemplate" is reserved for opting out of defaultTemplate. '
+            'Please use a different template name.',
+      );
+    }
+  }
 
   /// Reserved template name that opts out of [DeckOptions.defaultTemplate].
   ///
@@ -57,7 +66,7 @@ class TemplateResolver {
     if (template != null) {
       return _resolveWithTemplate(
         template,
-        templateName ?? 'default',
+        templateName ?? 'defaultTemplate',
         styleName,
       );
     }
@@ -72,9 +81,13 @@ class TemplateResolver {
 
       final template = _options.templates[templateName];
       if (template == null) {
+        final availableTemplates = _options.templates.keys.toList();
+        final availableMessage = availableTemplates.isEmpty
+            ? 'No templates are registered in this deck.'
+            : 'Available templates: ${availableTemplates.join(', ')}';
+
         throw TemplateException(
-          'Unknown template "$templateName". '
-          'Available templates: ${_options.templates.keys.join(', ')}',
+          'Unknown template "$templateName". $availableMessage',
         );
       }
       return template;

--- a/packages/superdeck/lib/superdeck.dart
+++ b/packages/superdeck/lib/superdeck.dart
@@ -23,6 +23,8 @@ export 'package:superdeck/src/deck/deck_controller.dart';
 export 'package:superdeck/src/deck/deck_options.dart';
 export 'package:superdeck/src/deck/deck_controller_builder.dart';
 export 'package:superdeck/src/deck/slide_configuration.dart';
+export 'package:superdeck/src/deck/slide_template.dart';
+export 'package:superdeck/src/deck/template_exception.dart';
 export 'package:superdeck/src/deck/widget_definition.dart';
 
 // Export

--- a/packages/superdeck/test/deck/slide_configuration_builder_test.dart
+++ b/packages/superdeck/test/deck/slide_configuration_builder_test.dart
@@ -1,0 +1,160 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:superdeck/src/deck/slide_configuration_builder.dart';
+import 'package:superdeck/superdeck.dart';
+
+void main() {
+  final config = DeckConfiguration();
+  final builder = SlideConfigurationBuilder(configuration: config);
+
+  group('SlideConfigurationBuilder', () {
+    test('returns empty list for empty slides', () {
+      final result = builder.buildConfigurations([], const DeckOptions());
+      expect(result, isEmpty);
+    });
+
+    test('backward compatibility — no templates, applies deck styles', () {
+      final baseStyle = SlideStyle();
+      final options = DeckOptions(baseStyle: baseStyle);
+      final slides = [const Slide(key: 'slide-1')];
+
+      final configs = builder.buildConfigurations(slides, options);
+
+      expect(configs.length, 1);
+      expect(configs[0].style, defaultSlideStyle.merge(baseStyle).merge(null));
+      expect(configs[0].parts, options.parts);
+    });
+
+    test('slide with named style resolves from deck styles', () {
+      final namedStyle = SlideStyle();
+      final options = DeckOptions(styles: {'dark': namedStyle});
+      final slides = [
+        const Slide(
+          key: 'styled',
+          options: SlideOptions(style: 'dark'),
+        ),
+      ];
+
+      final configs = builder.buildConfigurations(slides, options);
+
+      expect(configs[0].style, defaultSlideStyle.merge(null).merge(namedStyle));
+    });
+
+    test('slide with template uses template parts and style', () {
+      final templateBase = SlideStyle();
+      final templateParts = SlideParts();
+      final template = SlideTemplate(
+        baseStyle: templateBase,
+        parts: templateParts,
+      );
+      final options = DeckOptions(templates: {'corporate': template});
+      final slides = [
+        const Slide(
+          key: 'tmpl-slide',
+          options: SlideOptions(template: 'corporate'),
+        ),
+      ];
+
+      final configs = builder.buildConfigurations(slides, options);
+
+      expect(configs[0].style, defaultSlideStyle.merge(templateBase).merge(null));
+      expect(configs[0].parts, templateParts);
+    });
+
+    test('slide with template + style uses template style variants', () {
+      final variant = SlideStyle();
+      final template = SlideTemplate(styles: {'highlight': variant});
+      final options = DeckOptions(templates: {'t': template});
+      final slides = [
+        const Slide(
+          key: 'variant-slide',
+          options: SlideOptions(template: 't', style: 'highlight'),
+        ),
+      ];
+
+      final configs = builder.buildConfigurations(slides, options);
+
+      expect(configs[0].style, defaultSlideStyle.merge(null).merge(variant));
+    });
+
+    test('defaultTemplate applies to slides without explicit template', () {
+      final defaultTemplate = SlideTemplate(baseStyle: SlideStyle());
+      final options = DeckOptions(defaultTemplate: defaultTemplate);
+      final slides = [const Slide(key: 'default-tmpl')];
+
+      final configs = builder.buildConfigurations(slides, options);
+
+      expect(configs[0].parts, defaultTemplate.parts);
+    });
+
+    test('template: "none" opts out of defaultTemplate', () {
+      final defaultTemplate = SlideTemplate(baseStyle: SlideStyle());
+      final deckBase = SlideStyle();
+      final options = DeckOptions(
+        defaultTemplate: defaultTemplate,
+        baseStyle: deckBase,
+      );
+      final slides = [
+        const Slide(
+          key: 'no-tmpl',
+          options: SlideOptions(template: 'none'),
+        ),
+      ];
+
+      final configs = builder.buildConfigurations(slides, options);
+
+      expect(configs[0].parts, options.parts);
+      expect(configs[0].style, defaultSlideStyle.merge(deckBase).merge(null));
+    });
+
+    test('unknown template throws TemplateException', () {
+      final options = DeckOptions(templates: {'real': SlideTemplate()});
+      final slides = [
+        const Slide(
+          key: 'bad',
+          options: SlideOptions(template: 'fake'),
+        ),
+      ];
+
+      expect(
+        () => builder.buildConfigurations(slides, options),
+        throwsA(isA<TemplateException>()),
+      );
+    });
+
+    test('mixed slides — some with template, some without', () {
+      final template = SlideTemplate(baseStyle: SlideStyle());
+      final deckBase = SlideStyle();
+      final options = DeckOptions(
+        baseStyle: deckBase,
+        templates: {'t': template},
+      );
+      final slides = [
+        const Slide(key: 'plain'),
+        const Slide(
+          key: 'templated',
+          options: SlideOptions(template: 't'),
+        ),
+      ];
+
+      final configs = builder.buildConfigurations(slides, options);
+
+      expect(configs[0].parts, options.parts);
+      expect(configs[1].parts, template.parts);
+    });
+
+    test('slideIndex is correctly assigned', () {
+      final options = DeckOptions();
+      final slides = [
+        const Slide(key: 'a'),
+        const Slide(key: 'b'),
+        const Slide(key: 'c'),
+      ];
+
+      final configs = builder.buildConfigurations(slides, options);
+
+      expect(configs[0].slideIndex, 0);
+      expect(configs[1].slideIndex, 1);
+      expect(configs[2].slideIndex, 2);
+    });
+  });
+}

--- a/packages/superdeck/test/deck/slide_template_test.dart
+++ b/packages/superdeck/test/deck/slide_template_test.dart
@@ -1,0 +1,194 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:superdeck/superdeck.dart';
+
+void main() {
+  group('SlideTemplate', () {
+    group('construction', () {
+      test('default constructor produces expected field values', () {
+        const template = SlideTemplate();
+
+        expect(template.parts, isA<SlideParts>());
+        expect(template.baseStyle, isNull);
+        expect(template.styles, isEmpty);
+      });
+
+      test('all-parameter constructor stores supplied values', () {
+        final parts = SlideParts();
+        final baseStyle = SlideStyle();
+        final variants = <String, SlideStyle>{'dark': SlideStyle()};
+
+        final template = SlideTemplate(
+          parts: parts,
+          baseStyle: baseStyle,
+          styles: variants,
+        );
+
+        expect(template.parts, same(parts));
+        expect(template.baseStyle, same(baseStyle));
+        expect(template.styles, equals(variants));
+      });
+    });
+
+    group('copyWith', () {
+      test('copies parts field when supplied', () {
+        const original = SlideTemplate();
+        final newParts = SlideParts();
+
+        final copy = original.copyWith(parts: newParts);
+
+        expect(copy.parts, same(newParts));
+        expect(copy.baseStyle, isNull);
+        expect(copy.styles, isEmpty);
+      });
+
+      test('copies baseStyle field when supplied', () {
+        const original = SlideTemplate();
+        final newStyle = SlideStyle();
+
+        final copy = original.copyWith(baseStyle: newStyle);
+
+        expect(copy.baseStyle, same(newStyle));
+        expect(copy.parts, isA<SlideParts>());
+        expect(copy.styles, isEmpty);
+      });
+
+      test('copies styles field when supplied', () {
+        const original = SlideTemplate();
+        final newStyles = <String, SlideStyle>{'light': SlideStyle()};
+
+        final copy = original.copyWith(styles: newStyles);
+
+        expect(copy.styles, equals(newStyles));
+        expect(copy.baseStyle, isNull);
+      });
+
+      test('preserves parts when not specified', () {
+        final parts = SlideParts();
+        final original = SlideTemplate(parts: parts);
+
+        final copy = original.copyWith(baseStyle: SlideStyle());
+
+        expect(copy.parts, same(parts));
+      });
+
+      test('preserves baseStyle when not specified', () {
+        final baseStyle = SlideStyle();
+        final original = SlideTemplate(baseStyle: baseStyle);
+
+        final copy = original.copyWith(styles: {'x': SlideStyle()});
+
+        expect(copy.baseStyle, same(baseStyle));
+      });
+
+      test('preserves styles when not specified', () {
+        final styles = <String, SlideStyle>{'a': SlideStyle()};
+        final original = SlideTemplate(styles: styles);
+
+        final copy = original.copyWith(baseStyle: SlideStyle());
+
+        expect(copy.styles, same(styles));
+      });
+    });
+
+    group('equality', () {
+      test('two templates with the same shared parts instance are equal', () {
+        final parts = SlideParts();
+        final a = SlideTemplate(parts: parts);
+        final b = SlideTemplate(parts: parts);
+
+        expect(a, equals(b));
+      });
+
+      test('identical template is equal to itself', () {
+        const template = SlideTemplate();
+
+        expect(template, equals(template));
+      });
+
+      test('templates with different parts instances are not equal', () {
+        // SlideParts does not override ==, so distinct instances differ.
+        final a = SlideTemplate(parts: SlideParts());
+        final b = SlideTemplate(parts: SlideParts());
+
+        expect(a, isNot(equals(b)));
+      });
+
+      test('templates with different baseStyles are not equal', () {
+        final parts = SlideParts();
+        final a = SlideTemplate(
+          parts: parts,
+          baseStyle: SlideStyle(),
+        );
+        final b = SlideTemplate(parts: parts);
+
+        expect(a, isNot(equals(b)));
+      });
+
+      test('templates with equal baseStyles are equal', () {
+        // SlideStyle uses Equatable, so two instances with same args are equal.
+        final parts = SlideParts();
+        final a = SlideTemplate(parts: parts, baseStyle: SlideStyle());
+        final b = SlideTemplate(parts: parts, baseStyle: SlideStyle());
+
+        expect(a, equals(b));
+      });
+
+      test('templates with different styles maps are not equal', () {
+        final parts = SlideParts();
+        final a = SlideTemplate(
+          parts: parts,
+          styles: {'dark': SlideStyle()},
+        );
+        final b = SlideTemplate(parts: parts, styles: {});
+
+        expect(a, isNot(equals(b)));
+      });
+
+      test('templates sharing the same styles map instance are equal', () {
+        final parts = SlideParts();
+        final styles = <String, SlideStyle>{'dark': SlideStyle()};
+        final a = SlideTemplate(parts: parts, styles: styles);
+        final b = SlideTemplate(parts: parts, styles: styles);
+
+        expect(a, equals(b));
+      });
+    });
+
+    group('hashCode', () {
+      test('equal templates have the same hashCode', () {
+        final parts = SlideParts();
+        final baseStyle = SlideStyle();
+        final styles = <String, SlideStyle>{'x': SlideStyle()};
+
+        final a = SlideTemplate(
+          parts: parts,
+          baseStyle: baseStyle,
+          styles: styles,
+        );
+        final b = SlideTemplate(
+          parts: parts,
+          baseStyle: baseStyle,
+          styles: styles,
+        );
+
+        expect(a.hashCode, equals(b.hashCode));
+      });
+
+      test('hashCode is consistent across multiple calls on same instance', () {
+        const template = SlideTemplate();
+
+        expect(template.hashCode, equals(template.hashCode));
+      });
+
+      test('templates that differ in parts have different hashCodes', () {
+        // Different SlideParts instances have different identity-based hashCodes.
+        final a = SlideTemplate(parts: SlideParts());
+        final b = SlideTemplate(parts: SlideParts());
+
+        // Distinct SlideParts instances will produce distinct hash values
+        // in virtually all cases because Object.hashCode is identity-based.
+        expect(a.hashCode, isNot(equals(b.hashCode)));
+      });
+    });
+  });
+}

--- a/packages/superdeck/test/deck/template_resolver_test.dart
+++ b/packages/superdeck/test/deck/template_resolver_test.dart
@@ -1,0 +1,418 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:superdeck/src/deck/template_resolver.dart';
+import 'package:superdeck/superdeck.dart';
+
+void main() {
+  group('TemplateResolver', () {
+    group('No template', () {
+      test('no template, no style — returns defaultSlideStyle merged with options.baseStyle', () {
+        final baseStyle = SlideStyle();
+        final options = DeckOptions(baseStyle: baseStyle);
+        final resolver = TemplateResolver(options);
+
+        final result = resolver.resolve(null);
+
+        expect(result.usingTemplate, isFalse);
+        expect(result.parts, options.parts);
+        expect(result.style, defaultSlideStyle.merge(baseStyle).merge(null));
+      });
+
+      test('no template, no style, null slideOptions — returns defaultSlideStyle merged with baseStyle', () {
+        final options = DeckOptions();
+        final resolver = TemplateResolver(options);
+
+        final result = resolver.resolve(null);
+
+        expect(result.usingTemplate, isFalse);
+        expect(result.style, defaultSlideStyle.merge(null).merge(null));
+        expect(result.parts, options.parts);
+      });
+
+      test('no template, with style — resolves style from options.styles map', () {
+        final namedStyle = SlideStyle();
+        final options = DeckOptions(styles: {'dark': namedStyle});
+        final resolver = TemplateResolver(options);
+        const slideOptions = SlideOptions(style: 'dark');
+
+        final result = resolver.resolve(slideOptions);
+
+        expect(result.usingTemplate, isFalse);
+        expect(result.style, defaultSlideStyle.merge(null).merge(namedStyle));
+      });
+
+      test('no template, unknown style — throws TemplateException', () {
+        final options = DeckOptions(styles: {'light': SlideStyle()});
+        final resolver = TemplateResolver(options);
+        const slideOptions = SlideOptions(style: 'nonexistent');
+
+        expect(
+          () => resolver.resolve(slideOptions),
+          throwsA(isA<TemplateException>()),
+        );
+      });
+
+      test('no template, unknown style — exception message includes "in deck" and style name', () {
+        final options = DeckOptions(styles: {'light': SlideStyle(), 'dark': SlideStyle()});
+        final resolver = TemplateResolver(options);
+        const slideOptions = SlideOptions(style: 'missing');
+
+        expect(
+          () => resolver.resolve(slideOptions),
+          throwsA(
+            isA<TemplateException>().having(
+              (e) => e.message,
+              'message',
+              allOf(contains('missing'), contains('in deck')),
+            ),
+          ),
+        );
+      });
+    });
+
+    group('With template', () {
+      test('valid template — uses template baseStyle and parts', () {
+        final templateBaseStyle = SlideStyle();
+        final template = SlideTemplate(baseStyle: templateBaseStyle);
+        final options = DeckOptions(templates: {'hero': template});
+        final resolver = TemplateResolver(options);
+        const slideOptions = SlideOptions(template: 'hero');
+
+        final result = resolver.resolve(slideOptions);
+
+        expect(result.usingTemplate, isTrue);
+        expect(result.parts, template.parts);
+        expect(
+          result.style,
+          defaultSlideStyle.merge(templateBaseStyle).merge(null),
+        );
+      });
+
+      test('template with no baseStyle — uses defaultSlideStyle only', () {
+        final template = SlideTemplate();
+        final options = DeckOptions(templates: {'blank': template});
+        final resolver = TemplateResolver(options);
+        const slideOptions = SlideOptions(template: 'blank');
+
+        final result = resolver.resolve(slideOptions);
+
+        expect(result.usingTemplate, isTrue);
+        expect(result.style, defaultSlideStyle.merge(null).merge(null));
+      });
+
+      test('template + style — uses template styles map', () {
+        final templateStyle = SlideStyle();
+        final template = SlideTemplate(
+          styles: {'accent': templateStyle},
+        );
+        final options = DeckOptions(templates: {'branded': template});
+        final resolver = TemplateResolver(options);
+        const slideOptions = SlideOptions(template: 'branded', style: 'accent');
+
+        final result = resolver.resolve(slideOptions);
+
+        expect(result.usingTemplate, isTrue);
+        expect(
+          result.style,
+          defaultSlideStyle.merge(null).merge(templateStyle),
+        );
+      });
+
+      test('template, unknown style — throws TemplateException', () {
+        final template = SlideTemplate(
+          styles: {'known': SlideStyle()},
+        );
+        final options = DeckOptions(templates: {'myTemplate': template});
+        final resolver = TemplateResolver(options);
+        const slideOptions = SlideOptions(template: 'myTemplate', style: 'unknown');
+
+        expect(
+          () => resolver.resolve(slideOptions),
+          throwsA(isA<TemplateException>()),
+        );
+      });
+
+      test('template, unknown style — exception message includes template name and style name', () {
+        final template = SlideTemplate(
+          styles: {'valid': SlideStyle()},
+        );
+        final options = DeckOptions(templates: {'corporate': template});
+        final resolver = TemplateResolver(options);
+        const slideOptions = SlideOptions(template: 'corporate', style: 'bogus');
+
+        expect(
+          () => resolver.resolve(slideOptions),
+          throwsA(
+            isA<TemplateException>().having(
+              (e) => e.message,
+              'message',
+              allOf(contains('bogus'), contains('corporate')),
+            ),
+          ),
+        );
+      });
+
+      test('unknown template name — throws TemplateException', () {
+        final options = DeckOptions(templates: {'existing': SlideTemplate()});
+        final resolver = TemplateResolver(options);
+        const slideOptions = SlideOptions(template: 'doesNotExist');
+
+        expect(
+          () => resolver.resolve(slideOptions),
+          throwsA(isA<TemplateException>()),
+        );
+      });
+
+      test('unknown template name — exception message references the unknown template name', () {
+        final options = DeckOptions(templates: {'real': SlideTemplate()});
+        final resolver = TemplateResolver(options);
+        const slideOptions = SlideOptions(template: 'phantom');
+
+        expect(
+          () => resolver.resolve(slideOptions),
+          throwsA(
+            isA<TemplateException>().having(
+              (e) => e.message,
+              'message',
+              contains('phantom'),
+            ),
+          ),
+        );
+      });
+    });
+
+    group('defaultTemplate', () {
+      test('defaultTemplate used when slide has no explicit template', () {
+        final templateBaseStyle = SlideStyle();
+        final defaultTemplate = SlideTemplate(baseStyle: templateBaseStyle);
+        final options = DeckOptions(defaultTemplate: defaultTemplate);
+        final resolver = TemplateResolver(options);
+
+        final result = resolver.resolve(null);
+
+        expect(result.usingTemplate, isTrue);
+        expect(result.parts, defaultTemplate.parts);
+        expect(
+          result.style,
+          defaultSlideStyle.merge(templateBaseStyle).merge(null),
+        );
+      });
+
+      test('explicit template overrides defaultTemplate', () {
+        final defaultTemplateStyle = SlideStyle();
+        final explicitTemplateStyle = SlideStyle();
+
+        final defaultTemplate = SlideTemplate(baseStyle: defaultTemplateStyle);
+        final explicitTemplate = SlideTemplate(baseStyle: explicitTemplateStyle);
+
+        final options = DeckOptions(
+          defaultTemplate: defaultTemplate,
+          templates: {'explicit': explicitTemplate},
+        );
+        final resolver = TemplateResolver(options);
+        const slideOptions = SlideOptions(template: 'explicit');
+
+        final result = resolver.resolve(slideOptions);
+
+        expect(result.usingTemplate, isTrue);
+        expect(result.parts, explicitTemplate.parts);
+        expect(
+          result.style,
+          defaultSlideStyle.merge(explicitTemplateStyle).merge(null),
+        );
+      });
+
+      test('slide with no template field uses defaultTemplate when set', () {
+        final defaultTemplate = SlideTemplate();
+        final options = DeckOptions(defaultTemplate: defaultTemplate);
+        final resolver = TemplateResolver(options);
+        const slideOptions = SlideOptions(title: 'No template');
+
+        final result = resolver.resolve(slideOptions);
+
+        expect(result.usingTemplate, isTrue);
+        expect(result.parts, defaultTemplate.parts);
+      });
+
+      test('template: "none" opts out of defaultTemplate', () {
+        final defaultTemplate = SlideTemplate(baseStyle: SlideStyle());
+        final baseStyle = SlideStyle();
+        final options = DeckOptions(
+          defaultTemplate: defaultTemplate,
+          baseStyle: baseStyle,
+        );
+        final resolver = TemplateResolver(options);
+        const slideOptions = SlideOptions(template: 'none');
+
+        final result = resolver.resolve(slideOptions);
+
+        expect(result.usingTemplate, isFalse);
+        expect(result.parts, options.parts);
+        expect(result.style, defaultSlideStyle.merge(baseStyle).merge(null));
+      });
+
+      test('template: "none" uses deck-level styles, not template styles', () {
+        final deckStyle = SlideStyle();
+        final templateStyle = SlideStyle();
+        final options = DeckOptions(
+          defaultTemplate: SlideTemplate(baseStyle: templateStyle),
+          styles: {'accent': deckStyle},
+        );
+        final resolver = TemplateResolver(options);
+        const slideOptions = SlideOptions(template: 'none', style: 'accent');
+
+        final result = resolver.resolve(slideOptions);
+
+        expect(result.usingTemplate, isFalse);
+        expect(result.style, defaultSlideStyle.merge(null).merge(deckStyle));
+      });
+    });
+
+    group('Style merge order', () {
+      test('without template: defaultSlideStyle → options.baseStyle → options.styles[style]', () {
+        final baseStyle = SlideStyle();
+        final namedStyle = SlideStyle();
+        final options = DeckOptions(
+          baseStyle: baseStyle,
+          styles: {'variant': namedStyle},
+        );
+        final resolver = TemplateResolver(options);
+        const slideOptions = SlideOptions(style: 'variant');
+
+        final result = resolver.resolve(slideOptions);
+
+        final expected = defaultSlideStyle
+            .merge(baseStyle)
+            .merge(namedStyle);
+
+        expect(result.style, expected);
+      });
+
+      test('with template: defaultSlideStyle → template.baseStyle → template.styles[style]', () {
+        final templateBase = SlideStyle();
+        final templateVariant = SlideStyle();
+        final template = SlideTemplate(
+          baseStyle: templateBase,
+          styles: {'highlight': templateVariant},
+        );
+        final options = DeckOptions(templates: {'themed': template});
+        final resolver = TemplateResolver(options);
+        const slideOptions = SlideOptions(template: 'themed', style: 'highlight');
+
+        final result = resolver.resolve(slideOptions);
+
+        final expected = defaultSlideStyle
+            .merge(templateBase)
+            .merge(templateVariant);
+
+        expect(result.style, expected);
+      });
+
+      test('with template and no style variant: defaultSlideStyle → template.baseStyle', () {
+        final templateBase = SlideStyle();
+        final template = SlideTemplate(baseStyle: templateBase);
+        final options = DeckOptions(templates: {'simple': template});
+        final resolver = TemplateResolver(options);
+        const slideOptions = SlideOptions(template: 'simple');
+
+        final result = resolver.resolve(slideOptions);
+
+        final expected = defaultSlideStyle
+            .merge(templateBase)
+            .merge(null);
+
+        expect(result.style, expected);
+      });
+
+      test('options.baseStyle is not applied when a named template is used', () {
+        final optionsBaseStyle = SlideStyle();
+        final templateBase = SlideStyle();
+        final template = SlideTemplate(baseStyle: templateBase);
+        final options = DeckOptions(
+          baseStyle: optionsBaseStyle,
+          templates: {'t': template},
+        );
+        final resolver = TemplateResolver(options);
+        const slideOptions = SlideOptions(template: 't');
+
+        final result = resolver.resolve(slideOptions);
+
+        // Template path: usingTemplate=true, parts from template (not options)
+        expect(result.usingTemplate, isTrue);
+        expect(result.parts, template.parts);
+
+        // Without template: options.parts would be used
+        final noTemplateResult = TemplateResolver(
+          DeckOptions(baseStyle: optionsBaseStyle),
+        ).resolve(null);
+        expect(noTemplateResult.usingTemplate, isFalse);
+        expect(noTemplateResult.parts, options.parts);
+      });
+    });
+
+    group('usingTemplate flag', () {
+      test('is false when no template and no defaultTemplate', () {
+        final options = DeckOptions();
+        final resolver = TemplateResolver(options);
+
+        final result = resolver.resolve(null);
+
+        expect(result.usingTemplate, isFalse);
+      });
+
+      test('is true when explicit template is resolved', () {
+        final options = DeckOptions(templates: {'t': SlideTemplate()});
+        final resolver = TemplateResolver(options);
+        const slideOptions = SlideOptions(template: 't');
+
+        final result = resolver.resolve(slideOptions);
+
+        expect(result.usingTemplate, isTrue);
+      });
+
+      test('is true when defaultTemplate is used', () {
+        final options = DeckOptions(defaultTemplate: SlideTemplate());
+        final resolver = TemplateResolver(options);
+
+        final result = resolver.resolve(null);
+
+        expect(result.usingTemplate, isTrue);
+      });
+    });
+
+    group('Parts resolution', () {
+      test('returns options.parts when no template is used', () {
+        final options = DeckOptions();
+        final resolver = TemplateResolver(options);
+
+        final result = resolver.resolve(null);
+
+        expect(result.parts, options.parts);
+      });
+
+      test('returns template.parts when template is used', () {
+        final template = SlideTemplate();
+        final options = DeckOptions(templates: {'t': template});
+        final resolver = TemplateResolver(options);
+        const slideOptions = SlideOptions(template: 't');
+
+        final result = resolver.resolve(slideOptions);
+
+        expect(result.parts, template.parts);
+      });
+
+      test('template.parts differs from options.parts', () {
+        final template = SlideTemplate();
+        final options = DeckOptions(templates: {'t': template});
+        final resolver = TemplateResolver(options);
+        const slideOptions = SlideOptions(template: 't');
+
+        final withTemplate = resolver.resolve(slideOptions);
+        final withoutTemplate = resolver.resolve(null);
+
+        // When using a template, parts come from the template, not options
+        expect(withTemplate.parts, template.parts);
+        expect(withoutTemplate.parts, options.parts);
+      });
+    });
+  });
+}

--- a/packages/superdeck/test/deck/template_resolver_test.dart
+++ b/packages/superdeck/test/deck/template_resolver_test.dart
@@ -5,40 +5,49 @@ import 'package:superdeck/superdeck.dart';
 void main() {
   group('TemplateResolver', () {
     group('No template', () {
-      test('no template, no style — returns defaultSlideStyle merged with options.baseStyle', () {
-        final baseStyle = SlideStyle();
-        final options = DeckOptions(baseStyle: baseStyle);
-        final resolver = TemplateResolver(options);
+      test(
+        'no template, no style — returns defaultSlideStyle merged with options.baseStyle',
+        () {
+          final baseStyle = SlideStyle();
+          final options = DeckOptions(baseStyle: baseStyle);
+          final resolver = TemplateResolver(options);
 
-        final result = resolver.resolve(null);
+          final result = resolver.resolve(null);
 
-        expect(result.usingTemplate, isFalse);
-        expect(result.parts, options.parts);
-        expect(result.style, defaultSlideStyle.merge(baseStyle).merge(null));
-      });
+          expect(result.usingTemplate, isFalse);
+          expect(result.parts, options.parts);
+          expect(result.style, defaultSlideStyle.merge(baseStyle).merge(null));
+        },
+      );
 
-      test('no template, no style, null slideOptions — returns defaultSlideStyle merged with baseStyle', () {
-        final options = DeckOptions();
-        final resolver = TemplateResolver(options);
+      test(
+        'no template, no style, null slideOptions — returns defaultSlideStyle merged with baseStyle',
+        () {
+          final options = DeckOptions();
+          final resolver = TemplateResolver(options);
 
-        final result = resolver.resolve(null);
+          final result = resolver.resolve(null);
 
-        expect(result.usingTemplate, isFalse);
-        expect(result.style, defaultSlideStyle.merge(null).merge(null));
-        expect(result.parts, options.parts);
-      });
+          expect(result.usingTemplate, isFalse);
+          expect(result.style, defaultSlideStyle.merge(null).merge(null));
+          expect(result.parts, options.parts);
+        },
+      );
 
-      test('no template, with style — resolves style from options.styles map', () {
-        final namedStyle = SlideStyle();
-        final options = DeckOptions(styles: {'dark': namedStyle});
-        final resolver = TemplateResolver(options);
-        const slideOptions = SlideOptions(style: 'dark');
+      test(
+        'no template, with style — resolves style from options.styles map',
+        () {
+          final namedStyle = SlideStyle();
+          final options = DeckOptions(styles: {'dark': namedStyle});
+          final resolver = TemplateResolver(options);
+          const slideOptions = SlideOptions(style: 'dark');
 
-        final result = resolver.resolve(slideOptions);
+          final result = resolver.resolve(slideOptions);
 
-        expect(result.usingTemplate, isFalse);
-        expect(result.style, defaultSlideStyle.merge(null).merge(namedStyle));
-      });
+          expect(result.usingTemplate, isFalse);
+          expect(result.style, defaultSlideStyle.merge(null).merge(namedStyle));
+        },
+      );
 
       test('no template, unknown style — throws TemplateException', () {
         final options = DeckOptions(styles: {'light': SlideStyle()});
@@ -51,22 +60,27 @@ void main() {
         );
       });
 
-      test('no template, unknown style — exception message includes "in deck" and style name', () {
-        final options = DeckOptions(styles: {'light': SlideStyle(), 'dark': SlideStyle()});
-        final resolver = TemplateResolver(options);
-        const slideOptions = SlideOptions(style: 'missing');
+      test(
+        'no template, unknown style — exception message includes "in deck" and style name',
+        () {
+          final options = DeckOptions(
+            styles: {'light': SlideStyle(), 'dark': SlideStyle()},
+          );
+          final resolver = TemplateResolver(options);
+          const slideOptions = SlideOptions(style: 'missing');
 
-        expect(
-          () => resolver.resolve(slideOptions),
-          throwsA(
-            isA<TemplateException>().having(
-              (e) => e.message,
-              'message',
-              allOf(contains('missing'), contains('in deck')),
+          expect(
+            () => resolver.resolve(slideOptions),
+            throwsA(
+              isA<TemplateException>().having(
+                (e) => e.message,
+                'message',
+                allOf(contains('missing'), contains('in deck')),
+              ),
             ),
-          ),
-        );
-      });
+          );
+        },
+      );
     });
 
     group('With template', () {
@@ -101,9 +115,7 @@ void main() {
 
       test('template + style — uses template styles map', () {
         final templateStyle = SlideStyle();
-        final template = SlideTemplate(
-          styles: {'accent': templateStyle},
-        );
+        final template = SlideTemplate(styles: {'accent': templateStyle});
         final options = DeckOptions(templates: {'branded': template});
         final resolver = TemplateResolver(options);
         const slideOptions = SlideOptions(template: 'branded', style: 'accent');
@@ -118,12 +130,13 @@ void main() {
       });
 
       test('template, unknown style — throws TemplateException', () {
-        final template = SlideTemplate(
-          styles: {'known': SlideStyle()},
-        );
+        final template = SlideTemplate(styles: {'known': SlideStyle()});
         final options = DeckOptions(templates: {'myTemplate': template});
         final resolver = TemplateResolver(options);
-        const slideOptions = SlideOptions(template: 'myTemplate', style: 'unknown');
+        const slideOptions = SlideOptions(
+          template: 'myTemplate',
+          style: 'unknown',
+        );
 
         expect(
           () => resolver.resolve(slideOptions),
@@ -131,25 +144,29 @@ void main() {
         );
       });
 
-      test('template, unknown style — exception message includes template name and style name', () {
-        final template = SlideTemplate(
-          styles: {'valid': SlideStyle()},
-        );
-        final options = DeckOptions(templates: {'corporate': template});
-        final resolver = TemplateResolver(options);
-        const slideOptions = SlideOptions(template: 'corporate', style: 'bogus');
+      test(
+        'template, unknown style — exception message includes template name and style name',
+        () {
+          final template = SlideTemplate(styles: {'valid': SlideStyle()});
+          final options = DeckOptions(templates: {'corporate': template});
+          final resolver = TemplateResolver(options);
+          const slideOptions = SlideOptions(
+            template: 'corporate',
+            style: 'bogus',
+          );
 
-        expect(
-          () => resolver.resolve(slideOptions),
-          throwsA(
-            isA<TemplateException>().having(
-              (e) => e.message,
-              'message',
-              allOf(contains('bogus'), contains('corporate')),
+          expect(
+            () => resolver.resolve(slideOptions),
+            throwsA(
+              isA<TemplateException>().having(
+                (e) => e.message,
+                'message',
+                allOf(contains('bogus'), contains('corporate')),
+              ),
             ),
-          ),
-        );
-      });
+          );
+        },
+      );
 
       test('unknown template name — throws TemplateException', () {
         final options = DeckOptions(templates: {'existing': SlideTemplate()});
@@ -162,22 +179,48 @@ void main() {
         );
       });
 
-      test('unknown template name — exception message references the unknown template name', () {
-        final options = DeckOptions(templates: {'real': SlideTemplate()});
-        final resolver = TemplateResolver(options);
-        const slideOptions = SlideOptions(template: 'phantom');
+      test(
+        'unknown template name — exception message references the unknown template name',
+        () {
+          final options = DeckOptions(templates: {'real': SlideTemplate()});
+          final resolver = TemplateResolver(options);
+          const slideOptions = SlideOptions(template: 'phantom');
 
-        expect(
-          () => resolver.resolve(slideOptions),
-          throwsA(
-            isA<TemplateException>().having(
-              (e) => e.message,
-              'message',
-              contains('phantom'),
+          expect(
+            () => resolver.resolve(slideOptions),
+            throwsA(
+              isA<TemplateException>().having(
+                (e) => e.message,
+                'message',
+                contains('phantom'),
+              ),
             ),
-          ),
-        );
-      });
+          );
+        },
+      );
+
+      test(
+        'unknown template name — no registered templates message is explicit',
+        () {
+          final options = DeckOptions();
+          final resolver = TemplateResolver(options);
+          const slideOptions = SlideOptions(template: 'phantom');
+
+          expect(
+            () => resolver.resolve(slideOptions),
+            throwsA(
+              isA<TemplateException>().having(
+                (e) => e.message,
+                'message',
+                allOf(
+                  contains('phantom'),
+                  contains('No templates are registered in this deck.'),
+                ),
+              ),
+            ),
+          );
+        },
+      );
     });
 
     group('defaultTemplate', () {
@@ -202,7 +245,9 @@ void main() {
         final explicitTemplateStyle = SlideStyle();
 
         final defaultTemplate = SlideTemplate(baseStyle: defaultTemplateStyle);
-        final explicitTemplate = SlideTemplate(baseStyle: explicitTemplateStyle);
+        final explicitTemplate = SlideTemplate(
+          baseStyle: explicitTemplateStyle,
+        );
 
         final options = DeckOptions(
           defaultTemplate: defaultTemplate,
@@ -265,63 +310,107 @@ void main() {
         expect(result.usingTemplate, isFalse);
         expect(result.style, defaultSlideStyle.merge(null).merge(deckStyle));
       });
+
+      test(
+        'defaultTemplate unknown style message identifies defaultTemplate',
+        () {
+          final defaultTemplate = SlideTemplate(
+            styles: {'known': SlideStyle()},
+          );
+          final options = DeckOptions(defaultTemplate: defaultTemplate);
+          final resolver = TemplateResolver(options);
+          const slideOptions = SlideOptions(style: 'unknown');
+
+          expect(
+            () => resolver.resolve(slideOptions),
+            throwsA(
+              isA<TemplateException>().having(
+                (e) => e.message,
+                'message',
+                allOf(contains('defaultTemplate'), contains('unknown')),
+              ),
+            ),
+          );
+        },
+      );
+    });
+
+    group('Reserved template name', () {
+      test('throws when deck registers reserved "none" template name', () {
+        expect(
+          () => TemplateResolver(
+            DeckOptions(
+              templates: {TemplateResolver.noneTemplate: SlideTemplate()},
+            ),
+          ),
+          throwsA(isA<ArgumentError>()),
+        );
+      });
     });
 
     group('Style merge order', () {
-      test('without template: defaultSlideStyle → options.baseStyle → options.styles[style]', () {
-        final baseStyle = SlideStyle();
-        final namedStyle = SlideStyle();
-        final options = DeckOptions(
-          baseStyle: baseStyle,
-          styles: {'variant': namedStyle},
-        );
-        final resolver = TemplateResolver(options);
-        const slideOptions = SlideOptions(style: 'variant');
+      test(
+        'without template: defaultSlideStyle → options.baseStyle → options.styles[style]',
+        () {
+          final baseStyle = SlideStyle();
+          final namedStyle = SlideStyle();
+          final options = DeckOptions(
+            baseStyle: baseStyle,
+            styles: {'variant': namedStyle},
+          );
+          final resolver = TemplateResolver(options);
+          const slideOptions = SlideOptions(style: 'variant');
 
-        final result = resolver.resolve(slideOptions);
+          final result = resolver.resolve(slideOptions);
 
-        final expected = defaultSlideStyle
-            .merge(baseStyle)
-            .merge(namedStyle);
+          final expected = defaultSlideStyle.merge(baseStyle).merge(namedStyle);
 
-        expect(result.style, expected);
-      });
+          expect(result.style, expected);
+        },
+      );
 
-      test('with template: defaultSlideStyle → template.baseStyle → template.styles[style]', () {
-        final templateBase = SlideStyle();
-        final templateVariant = SlideStyle();
-        final template = SlideTemplate(
-          baseStyle: templateBase,
-          styles: {'highlight': templateVariant},
-        );
-        final options = DeckOptions(templates: {'themed': template});
-        final resolver = TemplateResolver(options);
-        const slideOptions = SlideOptions(template: 'themed', style: 'highlight');
+      test(
+        'with template: defaultSlideStyle → template.baseStyle → template.styles[style]',
+        () {
+          final templateBase = SlideStyle();
+          final templateVariant = SlideStyle();
+          final template = SlideTemplate(
+            baseStyle: templateBase,
+            styles: {'highlight': templateVariant},
+          );
+          final options = DeckOptions(templates: {'themed': template});
+          final resolver = TemplateResolver(options);
+          const slideOptions = SlideOptions(
+            template: 'themed',
+            style: 'highlight',
+          );
 
-        final result = resolver.resolve(slideOptions);
+          final result = resolver.resolve(slideOptions);
 
-        final expected = defaultSlideStyle
-            .merge(templateBase)
-            .merge(templateVariant);
+          final expected = defaultSlideStyle
+              .merge(templateBase)
+              .merge(templateVariant);
 
-        expect(result.style, expected);
-      });
+          expect(result.style, expected);
+        },
+      );
 
-      test('with template and no style variant: defaultSlideStyle → template.baseStyle', () {
-        final templateBase = SlideStyle();
-        final template = SlideTemplate(baseStyle: templateBase);
-        final options = DeckOptions(templates: {'simple': template});
-        final resolver = TemplateResolver(options);
-        const slideOptions = SlideOptions(template: 'simple');
+      test(
+        'with template and no style variant: defaultSlideStyle → template.baseStyle',
+        () {
+          final templateBase = SlideStyle();
+          final template = SlideTemplate(baseStyle: templateBase);
+          final options = DeckOptions(templates: {'simple': template});
+          final resolver = TemplateResolver(options);
+          const slideOptions = SlideOptions(template: 'simple');
 
-        final result = resolver.resolve(slideOptions);
+          final result = resolver.resolve(slideOptions);
 
-        final expected = defaultSlideStyle
-            .merge(templateBase)
-            .merge(null);
+          final expected = defaultSlideStyle.merge(templateBase).merge(null);
 
-        expect(result.style, expected);
-      });
+          expect(result.style, expected);
+        },
+      );
 
       test('options.baseStyle is not applied when a named template is used', () {
         final optionsBaseStyle = SlideStyle();


### PR DESCRIPTION
Adds a new slide template system that lets decks register named templates and an optional default template, with per-slide template selection through SlideOptions.template. Introduces SlideTemplate, TemplateException, and an internal TemplateResolver wired into SlideConfigurationBuilder, including explicit template: 'none' opt-out behavior and clearer template/deck style error messages. Updates superdeck_core slide model/schema support and exports public template APIs in superdeck.dart. Expands coverage with new resolver/template/builder tests plus core slide model tests, and updates the demo with template definitions, wiring, and example slides.md usage.