### PR TITLE
Refactor runtime thumbnail cache and URI pipeline

### DIFF
--- a/packages/core/lib/src/asset_cache_store.dart
+++ b/packages/core/lib/src/asset_cache_store.dart
@@ -1,7 +1,3 @@
-import 'dart:io';
-
-import 'package:path/path.dart' as p;
-
 /// Platform-agnostic cache contract for runtime-generated assets.
 ///
 /// The [assetKey] must be a bare filename (for example:
@@ -11,56 +7,4 @@ abstract class AssetCacheStore {
   Future<Uri?> resolve(String assetKey);
   Future<Uri?> write(String assetKey, List<int> bytes);
   Future<void> delete(String assetKey);
-}
-
-/// IO-backed [AssetCacheStore] that persists assets under [cacheDir].
-class IoAssetCacheStore implements AssetCacheStore {
-  final Directory cacheDir;
-
-  IoAssetCacheStore({required this.cacheDir});
-
-  @override
-  Future<Uri?> resolve(String assetKey) async {
-    final file = _assetFile(assetKey);
-    if (!await file.exists()) {
-      return null;
-    }
-    if (await file.length() == 0) {
-      return null;
-    }
-    return file.uri;
-  }
-
-  @override
-  Future<Uri?> write(String assetKey, List<int> bytes) async {
-    final file = _assetFile(assetKey);
-    await file.parent.create(recursive: true);
-    await file.writeAsBytes(bytes, flush: true);
-    return file.uri;
-  }
-
-  @override
-  Future<void> delete(String assetKey) async {
-    final file = _assetFile(assetKey);
-    if (await file.exists()) {
-      await file.delete();
-    }
-  }
-
-  File _assetFile(String assetKey) {
-    final normalizedKey = _normalizeAssetKey(assetKey);
-    return File(p.join(cacheDir.path, normalizedKey));
-  }
-
-  String _normalizeAssetKey(String assetKey) {
-    final normalized = p.basename(assetKey);
-    if (normalized.isEmpty || normalized != assetKey) {
-      throw ArgumentError.value(
-        assetKey,
-        'assetKey',
-        'Asset key must be a bare filename',
-      );
-    }
-    return normalized;
-  }
 }

--- a/packages/core/lib/src/asset_cache_store.dart
+++ b/packages/core/lib/src/asset_cache_store.dart
@@ -1,0 +1,66 @@
+import 'dart:io';
+
+import 'package:path/path.dart' as p;
+
+/// Platform-agnostic cache contract for runtime-generated assets.
+///
+/// The [assetKey] must be a bare filename (for example:
+/// `thumbnail_intro.png`). Implementations decide where and how keys
+/// are stored.
+abstract class AssetCacheStore {
+  Future<Uri?> resolve(String assetKey);
+  Future<Uri?> write(String assetKey, List<int> bytes);
+  Future<void> delete(String assetKey);
+}
+
+/// IO-backed [AssetCacheStore] that persists assets under [cacheDir].
+class IoAssetCacheStore implements AssetCacheStore {
+  final Directory cacheDir;
+
+  IoAssetCacheStore({required this.cacheDir});
+
+  @override
+  Future<Uri?> resolve(String assetKey) async {
+    final file = _assetFile(assetKey);
+    if (!await file.exists()) {
+      return null;
+    }
+    if (await file.length() == 0) {
+      return null;
+    }
+    return file.uri;
+  }
+
+  @override
+  Future<Uri?> write(String assetKey, List<int> bytes) async {
+    final file = _assetFile(assetKey);
+    await file.parent.create(recursive: true);
+    await file.writeAsBytes(bytes, flush: true);
+    return file.uri;
+  }
+
+  @override
+  Future<void> delete(String assetKey) async {
+    final file = _assetFile(assetKey);
+    if (await file.exists()) {
+      await file.delete();
+    }
+  }
+
+  File _assetFile(String assetKey) {
+    final normalizedKey = _normalizeAssetKey(assetKey);
+    return File(p.join(cacheDir.path, normalizedKey));
+  }
+
+  String _normalizeAssetKey(String assetKey) {
+    final normalized = p.basename(assetKey);
+    if (normalized.isEmpty || normalized != assetKey) {
+      throw ArgumentError.value(
+        assetKey,
+        'assetKey',
+        'Asset key must be a bare filename',
+      );
+    }
+    return normalized;
+  }
+}

--- a/packages/core/lib/src/asset_cache_store_io.dart
+++ b/packages/core/lib/src/asset_cache_store_io.dart
@@ -1,0 +1,60 @@
+import 'dart:io';
+
+import 'package:path/path.dart' as p;
+
+import 'asset_cache_store.dart';
+
+/// IO-backed [AssetCacheStore] that persists assets under [cacheDir].
+class IoAssetCacheStore implements AssetCacheStore {
+  final Directory cacheDir;
+
+  IoAssetCacheStore({required this.cacheDir});
+
+  @override
+  Future<Uri?> resolve(String assetKey) async {
+    final file = _assetFile(assetKey);
+    if (!await file.exists()) {
+      return null;
+    }
+    if (await file.length() == 0) {
+      return null;
+    }
+    return file.uri;
+  }
+
+  @override
+  Future<Uri?> write(String assetKey, List<int> bytes) async {
+    final file = _assetFile(assetKey);
+    if (bytes.isEmpty) {
+      return null;
+    }
+    await file.parent.create(recursive: true);
+    await file.writeAsBytes(bytes, flush: true);
+    return file.uri;
+  }
+
+  @override
+  Future<void> delete(String assetKey) async {
+    final file = _assetFile(assetKey);
+    if (await file.exists()) {
+      await file.delete();
+    }
+  }
+
+  File _assetFile(String assetKey) {
+    final normalizedKey = _normalizeAssetKey(assetKey);
+    return File(p.join(cacheDir.path, normalizedKey));
+  }
+
+  String _normalizeAssetKey(String assetKey) {
+    final normalized = p.basename(assetKey);
+    if (normalized.isEmpty || normalized != assetKey) {
+      throw ArgumentError.value(
+        assetKey,
+        'assetKey',
+        'Asset key must be a bare filename',
+      );
+    }
+    return normalized;
+  }
+}

--- a/packages/core/lib/superdeck_core.dart
+++ b/packages/core/lib/superdeck_core.dart
@@ -8,6 +8,7 @@ export 'src/models/block_model.dart';
 export 'src/models/deck_model.dart';
 export 'src/models/slide_model.dart';
 export 'src/asset_cache_store.dart';
+export 'src/asset_cache_store_io.dart';
 export 'src/deck_configuration.dart';
 export 'src/deck_service.dart';
 export 'src/deck_format_exception.dart';

--- a/packages/core/lib/superdeck_core.dart
+++ b/packages/core/lib/superdeck_core.dart
@@ -7,6 +7,7 @@ export 'src/models/asset_model.dart';
 export 'src/models/block_model.dart';
 export 'src/models/deck_model.dart';
 export 'src/models/slide_model.dart';
+export 'src/asset_cache_store.dart';
 export 'src/deck_configuration.dart';
 export 'src/deck_service.dart';
 export 'src/deck_format_exception.dart';

--- a/packages/core/test/src/asset_cache_store_test.dart
+++ b/packages/core/test/src/asset_cache_store_test.dart
@@ -34,6 +34,18 @@ void main() {
       expect(await file.readAsBytes(), bytes);
     });
 
+    test('write skips empty payloads', () async {
+      const key = 'thumbnail_empty.png';
+      final file = File(p.join(tempDir.path, key));
+
+      final writtenUri = await store.write(key, const []);
+      final resolvedUri = await store.resolve(key);
+
+      expect(writtenUri, isNull);
+      expect(resolvedUri, isNull);
+      expect(await file.exists(), isFalse);
+    });
+
     test('delete removes stored asset', () async {
       const key = 'thumbnail_slide.png';
       await store.write(key, [9, 8, 7]);

--- a/packages/core/test/src/asset_cache_store_test.dart
+++ b/packages/core/test/src/asset_cache_store_test.dart
@@ -1,0 +1,57 @@
+import 'dart:io';
+
+import 'package:path/path.dart' as p;
+import 'package:superdeck_core/superdeck_core.dart';
+import 'package:test/test.dart';
+
+import 'helpers/testing_utils.dart';
+
+void main() {
+  group('IoAssetCacheStore', () {
+    late Directory tempDir;
+    late IoAssetCacheStore store;
+
+    setUp(() {
+      tempDir = createTempDir();
+      store = IoAssetCacheStore(cacheDir: tempDir);
+    });
+
+    test('resolve returns null when key is missing', () async {
+      final uri = await store.resolve('thumbnail_missing.png');
+      expect(uri, isNull);
+    });
+
+    test('write persists bytes and resolve returns the file uri', () async {
+      final key = 'thumbnail_intro.png';
+      final bytes = [1, 2, 3];
+
+      final writtenUri = await store.write(key, bytes);
+      final resolvedUri = await store.resolve(key);
+      final file = File(p.join(tempDir.path, key));
+
+      expect(writtenUri, equals(file.uri));
+      expect(resolvedUri, equals(file.uri));
+      expect(await file.readAsBytes(), bytes);
+    });
+
+    test('delete removes stored asset', () async {
+      const key = 'thumbnail_slide.png';
+      await store.write(key, [9, 8, 7]);
+
+      await store.delete(key);
+
+      expect(await store.resolve(key), isNull);
+    });
+
+    test('rejects non-key path values', () async {
+      expect(
+        () => store.resolve('nested/thumbnail.png'),
+        throwsA(isA<ArgumentError>()),
+      );
+      expect(
+        () => store.write('../thumbnail.png', [1]),
+        throwsA(isA<ArgumentError>()),
+      );
+    });
+  });
+}

--- a/packages/superdeck/lib/src/deck/deck_controller.dart
+++ b/packages/superdeck/lib/src/deck/deck_controller.dart
@@ -9,6 +9,7 @@ import 'package:superdeck_core/superdeck_core.dart';
 import '../export/async_thumbnail.dart';
 import '../export/thumbnail_service.dart';
 import '../ui/widgets/provider.dart';
+import '../utils/asset_cache_store.dart';
 import '../utils/constants.dart';
 import 'deck_options.dart';
 import 'navigation_events.dart';
@@ -128,7 +129,13 @@ class DeckController {
     ThumbnailService? thumbnailService,
   }) : _deckService = deckService,
        _navigationService = navigationService ?? NavigationService(),
-       _thumbnailService = thumbnailService ?? ThumbnailService(),
+       _thumbnailService =
+           thumbnailService ??
+           ThumbnailService(
+             cacheStore: createAssetCacheStore(
+               configuration: deckService.configuration,
+             ),
+           ),
        _enableDeckStream = enableDeckStream {
     _options.value = options;
 

--- a/packages/superdeck/lib/src/deck/slide_configuration.dart
+++ b/packages/superdeck/lib/src/deck/slide_configuration.dart
@@ -13,6 +13,7 @@ class SlideConfiguration {
   final bool debug;
   final SlideParts? parts;
   final Map<String, WidgetDefinition> _widgets;
+  // Bare thumbnail asset key (for example: thumbnail_intro.png).
   final String thumbnailFile;
 
   final bool isExporting;

--- a/packages/superdeck/lib/src/deck/slide_configuration_builder.dart
+++ b/packages/superdeck/lib/src/deck/slide_configuration_builder.dart
@@ -1,4 +1,3 @@
-import 'package:path/path.dart' as p;
 import 'package:superdeck_core/superdeck_core.dart';
 
 import '../widgets/widgets.dart';
@@ -60,12 +59,8 @@ class SlideConfigurationBuilder {
       }
     }
 
-    // Generate thumbnail path using slide key and assets directory
+    // Generate thumbnail asset key using slide key.
     final thumbnailAsset = GeneratedAsset.thumbnail(slide.key);
-    final thumbnailPath = p.join(
-      configuration.assetsDir.path,
-      thumbnailAsset.fileName,
-    );
 
     // Resolve template, style, and parts
     final resolution = resolver.resolve(slide.options);
@@ -75,7 +70,7 @@ class SlideConfigurationBuilder {
       style: resolution.style,
       slide: slide,
       widgets: widgets,
-      thumbnailFile: thumbnailPath,
+      thumbnailFile: thumbnailAsset.fileName,
       parts: resolution.parts,
       debug: options.debug,
     );

--- a/packages/superdeck/lib/src/export/async_thumbnail.dart
+++ b/packages/superdeck/lib/src/export/async_thumbnail.dart
@@ -1,5 +1,4 @@
 import 'dart:async';
-import 'dart:io';
 
 import 'package:flutter/widgets.dart';
 import 'package:signals_flutter/signals_flutter.dart';
@@ -7,7 +6,7 @@ import 'package:superdeck/src/ui/ui.dart';
 import 'package:superdeck/src/ui/widgets/cache_image_widget.dart';
 
 typedef AsyncFileGenerator =
-    Future<File> Function(BuildContext context, bool force);
+    Future<Uri?> Function(BuildContext context, bool force);
 
 enum AsyncFileStatus { idle, loading, done, error }
 
@@ -18,7 +17,7 @@ class AsyncThumbnail {
 
   // Signals for reactive state
   final _status = signal<AsyncFileStatus>(AsyncFileStatus.idle);
-  final _imageFile = signal<File?>(null);
+  final _imageUri = signal<Uri?>(null);
   final _error = signal<Object?>(null);
 
   // Non-reactive internal state
@@ -37,21 +36,27 @@ class AsyncThumbnail {
     _isGenerating = true;
 
     _status.value = AsyncFileStatus.loading;
-    final currentFile = _imageFile.value;
-    if (currentFile != null) {
-      // Clear all cached images to ensure stale thumbnails don't linger
-      imageCache.clear();
-      FileImage(currentFile).evict();
+    final currentUri = _imageUri.value;
+    if (currentUri != null) {
+      // Evict only the previous thumbnail provider to avoid global cache churn.
+      imageCache.evict(getImageProvider(currentUri));
     }
-    _imageFile.value = null;
+    _imageUri.value = null;
 
     try {
-      final file = await _generator(context, force);
+      final uri = await _generator(context, force);
 
       // Guard after async - disposal could have happened during generation
       if (_disposed) return;
 
-      _imageFile.value = file;
+      if (uri == null) {
+        _status.value = AsyncFileStatus.error;
+        _error.value = StateError('Thumbnail unavailable');
+        _imageUri.value = null;
+        return;
+      }
+
+      _imageUri.value = uri;
       _status.value = AsyncFileStatus.done;
       _error.value = null;
     } catch (error, _) {
@@ -60,7 +65,7 @@ class AsyncThumbnail {
 
       _status.value = AsyncFileStatus.error;
       _error.value = error;
-      _imageFile.value = null;
+      _imageUri.value = null;
     } finally {
       _isGenerating = false;
     }
@@ -71,7 +76,7 @@ class AsyncThumbnail {
 
     // Dispose signals
     _status.dispose();
-    _imageFile.dispose();
+    _imageUri.dispose();
     _error.dispose();
   }
 
@@ -99,12 +104,12 @@ class AsyncThumbnail {
   ///
   /// Returns null if the file has not been generated yet.
   ImageProvider<Object>? get imageProvider {
-    final file = _imageFile.value;
-    if (file == null) {
+    final uri = _imageUri.value;
+    if (uri == null) {
       return null;
     }
 
-    return getImageProvider(file.uri);
+    return getImageProvider(uri);
   }
 
   Widget build(BuildContext context) {

--- a/packages/superdeck/lib/src/export/thumbnail_service.dart
+++ b/packages/superdeck/lib/src/export/thumbnail_service.dart
@@ -1,6 +1,5 @@
-import 'dart:io';
-
 import 'package:flutter/widgets.dart';
+import 'package:superdeck_core/superdeck_core.dart';
 
 import '../deck/slide_configuration.dart';
 import 'async_thumbnail.dart';
@@ -12,14 +11,19 @@ import 'slide_capture_service.dart';
 /// any state. The controller using this service owns the cache and is
 /// notified of updates via the [onCacheUpdate] callback.
 class ThumbnailService {
+  final AssetCacheStore _cacheStore;
   final SlideCaptureService _slideCaptureService;
 
   /// Creates a ThumbnailService.
   ///
+  /// [cacheStore] is required and handles key-based cache resolution.
   /// [slideCaptureService] can be injected for testing. If not provided,
   /// a default instance is created.
-  ThumbnailService({SlideCaptureService? slideCaptureService})
-    : _slideCaptureService = slideCaptureService ?? SlideCaptureService();
+  ThumbnailService({
+    required AssetCacheStore cacheStore,
+    SlideCaptureService? slideCaptureService,
+  }) : _cacheStore = cacheStore,
+       _slideCaptureService = slideCaptureService ?? SlideCaptureService();
 
   /// Generates thumbnails for all slides, updating the cache as needed.
   ///
@@ -41,7 +45,8 @@ class ThumbnailService {
       final thumbnail = updatedCache.putIfAbsent(
         slide.key,
         () => AsyncThumbnail(
-          generator: (ctx, force) => _generateThumbnail(slide, ctx, force),
+          generator: (ctx, force) =>
+              generateThumbnail(slide: slide, context: ctx, force: force),
         ),
       );
       thumbnail.load(context, force);
@@ -52,18 +57,25 @@ class ThumbnailService {
 
   /// Generates a single thumbnail for a slide.
   ///
-  /// Returns the existing thumbnail file if [force] is false and the file
-  /// exists with non-zero size. Otherwise, captures a new thumbnail using
-  /// [SlideCaptureService] and writes it to disk.
-  Future<File> _generateThumbnail(
-    SlideConfiguration slide,
-    BuildContext context,
-    bool force,
-  ) async {
-    final file = File(slide.thumbnailFile);
-
-    if (!force && await file.exists() && await file.length() > 0) {
-      return file;
+  /// Resolve order:
+  /// 1. Cache store resolve (app cache first, then bundled fallback by platform)
+  /// 2. Capture/generate fresh
+  /// 3. Cache store write
+  ///
+  /// Returns null when nothing can be resolved/generated.
+  @visibleForTesting
+  Future<Uri?> generateThumbnail({
+    required SlideConfiguration slide,
+    required BuildContext context,
+    required bool force,
+  }) async {
+    if (!force) {
+      final resolvedUri = await _cacheStore.resolve(slide.thumbnailFile);
+      if (resolvedUri != null) {
+        return resolvedUri;
+      }
+    } else {
+      await _cacheStore.delete(slide.thumbnailFile);
     }
 
     final imageData = await _slideCaptureService.capture(
@@ -72,7 +84,6 @@ class ThumbnailService {
       context: context,
     );
 
-    await file.writeAsBytes(imageData);
-    return file;
+    return _cacheStore.write(slide.thumbnailFile, imageData);
   }
 }

--- a/packages/superdeck/lib/src/ui/app_shell.dart
+++ b/packages/superdeck/lib/src/ui/app_shell.dart
@@ -49,7 +49,6 @@ class _SplitViewState extends State<SplitView>
   late final Animation<double> _curvedAnimation;
   bool _isInitialized = false;
   EffectCleanup? _menuEffectCleanup;
-  EffectCleanup? _thumbnailSyncEffectCleanup;
 
   @override
   void initState() {
@@ -95,20 +94,6 @@ class _SplitViewState extends State<SplitView>
           _animationController.reverse();
         }
       });
-
-      // Sync thumbnail generation with slide changes without triggering rebuilds.
-      // Use effect instead of Watch to avoid infinite rebuild loops.
-      _thumbnailSyncEffectCleanup = effect(() {
-        // Track slides signal - effect will re-run when slides change
-        deckController.slides.value;
-
-        // Regenerate thumbnails after frame completes
-        WidgetsBinding.instance.addPostFrameCallback((_) {
-          if (mounted) {
-            deckController.generateThumbnails(context);
-          }
-        });
-      });
     }
   }
 
@@ -116,7 +101,6 @@ class _SplitViewState extends State<SplitView>
   void dispose() {
     // Cleanup effect
     _menuEffectCleanup?.call();
-    _thumbnailSyncEffectCleanup?.call();
     _animationController.dispose();
     super.dispose();
   }

--- a/packages/superdeck/lib/src/ui/widgets/cache_image_widget.dart
+++ b/packages/superdeck/lib/src/ui/widgets/cache_image_widget.dart
@@ -18,6 +18,12 @@ ImageProvider getImageProvider(Uri uri) {
         return AssetImage(uri.path);
       }
       return FileImage(File.fromUri(uri));
+    case 'data':
+      final bytes = uri.data?.contentAsBytes();
+      if (bytes == null) {
+        return AssetImage(uri.path);
+      }
+      return MemoryImage(Uint8List.fromList(bytes));
     default:
       // On platforms that can run processes (desktop debug), files are
       // generated at runtime and loaded from the filesystem.

--- a/packages/superdeck/lib/src/ui/widgets/cache_image_widget.dart
+++ b/packages/superdeck/lib/src/ui/widgets/cache_image_widget.dart
@@ -23,7 +23,7 @@ ImageProvider getImageProvider(Uri uri) {
       if (bytes == null) {
         return AssetImage(uri.path);
       }
-      return MemoryImage(Uint8List.fromList(bytes));
+      return MemoryImage(bytes);
     default:
       // On platforms that can run processes (desktop debug), files are
       // generated at runtime and loaded from the filesystem.

--- a/packages/superdeck/lib/src/utils/asset_cache_store.dart
+++ b/packages/superdeck/lib/src/utils/asset_cache_store.dart
@@ -1,0 +1,3 @@
+export 'asset_cache_store_stub.dart'
+    if (dart.library.js_interop) 'asset_cache_store_web.dart'
+    if (dart.library.io) 'asset_cache_store_io.dart';

--- a/packages/superdeck/lib/src/utils/asset_cache_store_io.dart
+++ b/packages/superdeck/lib/src/utils/asset_cache_store_io.dart
@@ -1,0 +1,75 @@
+import 'dart:io';
+
+import 'package:path/path.dart' as p;
+import 'package:superdeck_core/superdeck_core.dart';
+
+AssetCacheStore createAssetCacheStore({
+  required DeckConfiguration configuration,
+}) {
+  final cacheScope = GeneratedAsset.buildKey(
+    configuration.superdeckDir.absolute.path,
+  );
+  final cacheDir = Directory(
+    p.join(Directory.systemTemp.path, 'superdeck', 'asset_cache', cacheScope),
+  );
+
+  return _IoRuntimeAssetCacheStore(
+    cacheStore: IoAssetCacheStore(cacheDir: cacheDir),
+    bundledAssetsDir: configuration.assetsDir,
+  );
+}
+
+class _IoRuntimeAssetCacheStore implements AssetCacheStore {
+  final IoAssetCacheStore _cacheStore;
+  final Directory _bundledAssetsDir;
+
+  _IoRuntimeAssetCacheStore({
+    required IoAssetCacheStore cacheStore,
+    required Directory bundledAssetsDir,
+  }) : _cacheStore = cacheStore,
+       _bundledAssetsDir = bundledAssetsDir;
+
+  @override
+  Future<Uri?> resolve(String assetKey) async {
+    final normalizedKey = _normalizeAssetKey(assetKey);
+
+    final appCacheUri = await _cacheStore.resolve(normalizedKey);
+    if (appCacheUri != null) {
+      return appCacheUri;
+    }
+
+    final bundledFile = File(p.join(_bundledAssetsDir.path, normalizedKey));
+    if (!await bundledFile.exists()) {
+      return null;
+    }
+    if (await bundledFile.length() == 0) {
+      return null;
+    }
+
+    return bundledFile.uri;
+  }
+
+  @override
+  Future<Uri?> write(String assetKey, List<int> bytes) {
+    final normalizedKey = _normalizeAssetKey(assetKey);
+    return _cacheStore.write(normalizedKey, bytes);
+  }
+
+  @override
+  Future<void> delete(String assetKey) {
+    final normalizedKey = _normalizeAssetKey(assetKey);
+    return _cacheStore.delete(normalizedKey);
+  }
+
+  String _normalizeAssetKey(String assetKey) {
+    final normalized = p.basename(assetKey);
+    if (normalized.isEmpty || normalized != assetKey) {
+      throw ArgumentError.value(
+        assetKey,
+        'assetKey',
+        'Asset key must be a bare filename',
+      );
+    }
+    return normalized;
+  }
+}

--- a/packages/superdeck/lib/src/utils/asset_cache_store_stub.dart
+++ b/packages/superdeck/lib/src/utils/asset_cache_store_stub.dart
@@ -1,0 +1,18 @@
+import 'package:superdeck_core/superdeck_core.dart';
+
+AssetCacheStore createAssetCacheStore({
+  required DeckConfiguration configuration,
+}) {
+  return _StubAssetCacheStore();
+}
+
+class _StubAssetCacheStore implements AssetCacheStore {
+  @override
+  Future<Uri?> resolve(String assetKey) async => null;
+
+  @override
+  Future<Uri?> write(String assetKey, List<int> bytes) async => null;
+
+  @override
+  Future<void> delete(String assetKey) async {}
+}

--- a/packages/superdeck/lib/src/utils/asset_cache_store_web.dart
+++ b/packages/superdeck/lib/src/utils/asset_cache_store_web.dart
@@ -30,10 +30,18 @@ class _WebAssetCacheStore implements AssetCacheStore {
     final bundledPath = p.posix.join(_bundledAssetsPath, normalizedKey);
     try {
       final byteData = await rootBundle.load(bundledPath);
-      if (byteData.lengthInBytes == 0) {
+      final bundledBytes = byteData.buffer.asUint8List(
+        byteData.offsetInBytes,
+        byteData.lengthInBytes,
+      );
+      if (bundledBytes.isEmpty) {
         return null;
       }
-      return Uri(path: bundledPath);
+      _cache[normalizedKey] = bundledBytes;
+      return Uri.dataFromBytes(
+        bundledBytes,
+        mimeType: _mimeTypeForAssetKey(normalizedKey),
+      );
     } on Object {
       return null;
     }

--- a/packages/superdeck/lib/src/utils/asset_cache_store_web.dart
+++ b/packages/superdeck/lib/src/utils/asset_cache_store_web.dart
@@ -1,0 +1,89 @@
+import 'package:flutter/services.dart';
+import 'package:path/path.dart' as p;
+import 'package:superdeck_core/superdeck_core.dart';
+
+AssetCacheStore createAssetCacheStore({
+  required DeckConfiguration configuration,
+}) {
+  return _WebAssetCacheStore(bundledAssetsPath: configuration.assetsDir.path);
+}
+
+class _WebAssetCacheStore implements AssetCacheStore {
+  final Map<String, Uint8List> _cache = {};
+  final String _bundledAssetsPath;
+
+  _WebAssetCacheStore({required String bundledAssetsPath})
+    : _bundledAssetsPath = _normalizePath(bundledAssetsPath);
+
+  @override
+  Future<Uri?> resolve(String assetKey) async {
+    final normalizedKey = _normalizeAssetKey(assetKey);
+
+    final cachedBytes = _cache[normalizedKey];
+    if (cachedBytes != null && cachedBytes.isNotEmpty) {
+      return Uri.dataFromBytes(
+        cachedBytes,
+        mimeType: _mimeTypeForAssetKey(normalizedKey),
+      );
+    }
+
+    final bundledPath = p.posix.join(_bundledAssetsPath, normalizedKey);
+    try {
+      final byteData = await rootBundle.load(bundledPath);
+      if (byteData.lengthInBytes == 0) {
+        return null;
+      }
+      return Uri(path: bundledPath);
+    } on Object {
+      return null;
+    }
+  }
+
+  @override
+  Future<Uri?> write(String assetKey, List<int> bytes) async {
+    final normalizedKey = _normalizeAssetKey(assetKey);
+    final data = Uint8List.fromList(bytes);
+    if (data.isEmpty) {
+      return null;
+    }
+
+    _cache[normalizedKey] = data;
+    return Uri.dataFromBytes(
+      data,
+      mimeType: _mimeTypeForAssetKey(normalizedKey),
+    );
+  }
+
+  @override
+  Future<void> delete(String assetKey) async {
+    final normalizedKey = _normalizeAssetKey(assetKey);
+    _cache.remove(normalizedKey);
+  }
+
+  static String _normalizePath(String path) {
+    return path.replaceAll('\\', '/');
+  }
+
+  String _normalizeAssetKey(String assetKey) {
+    final normalized = p.basename(assetKey);
+    if (normalized.isEmpty || normalized != assetKey) {
+      throw ArgumentError.value(
+        assetKey,
+        'assetKey',
+        'Asset key must be a bare filename',
+      );
+    }
+    return normalized;
+  }
+
+  String _mimeTypeForAssetKey(String assetKey) {
+    return switch (p.extension(assetKey).toLowerCase()) {
+      '.png' => 'image/png',
+      '.jpg' || '.jpeg' => 'image/jpeg',
+      '.gif' => 'image/gif',
+      '.webp' => 'image/webp',
+      '.svg' => 'image/svg+xml',
+      _ => 'application/octet-stream',
+    };
+  }
+}

--- a/packages/superdeck/test/deck/deck_controller_test.dart
+++ b/packages/superdeck/test/deck/deck_controller_test.dart
@@ -1,7 +1,6 @@
 import 'dart:async';
 
 import 'package:flutter_test/flutter_test.dart';
-import 'package:path/path.dart' as p;
 import 'package:superdeck/src/deck/deck_controller.dart';
 import 'package:superdeck/src/deck/deck_options.dart';
 import 'package:superdeck_core/superdeck_core.dart';
@@ -255,7 +254,7 @@ void main() {
         expect(controller.slides.value, hasLength(1));
         expect(
           controller.slides.value.first.thumbnailFile,
-          p.join('.webdeck', 'img', 'thumbnail_web-config.png'),
+          'thumbnail_web-config.png',
         );
       });
 
@@ -292,11 +291,7 @@ void main() {
             expect(tempController.slides.value, hasLength(1));
             expect(
               tempController.slides.value.first.thumbnailFile,
-              p.join(
-                '.service',
-                'svc_assets',
-                'thumbnail_service-fallback.png',
-              ),
+              'thumbnail_service-fallback.png',
             );
           } finally {
             tempController.dispose();

--- a/packages/superdeck/test/deck/slide_configuration_builder_test.dart
+++ b/packages/superdeck/test/deck/slide_configuration_builder_test.dart
@@ -56,7 +56,10 @@ void main() {
 
       final configs = builder.buildConfigurations(slides, options);
 
-      expect(configs[0].style, defaultSlideStyle.merge(templateBase).merge(null));
+      expect(
+        configs[0].style,
+        defaultSlideStyle.merge(templateBase).merge(null),
+      );
       expect(configs[0].parts, templateParts);
     });
 
@@ -155,6 +158,15 @@ void main() {
       expect(configs[0].slideIndex, 0);
       expect(configs[1].slideIndex, 1);
       expect(configs[2].slideIndex, 2);
+    });
+
+    test('thumbnailFile stores generated asset key only', () {
+      final options = DeckOptions();
+      final slides = [const Slide(key: 'cover')];
+
+      final configs = builder.buildConfigurations(slides, options);
+
+      expect(configs.first.thumbnailFile, 'thumbnail_cover.png');
     });
   });
 }

--- a/packages/superdeck/test/export/thumbnail_service_test.dart
+++ b/packages/superdeck/test/export/thumbnail_service_test.dart
@@ -1,105 +1,182 @@
-import 'dart:io';
+import 'dart:typed_data';
 
+import 'package:flutter/widgets.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:superdeck/superdeck.dart';
+import 'package:superdeck/src/export/slide_capture_service.dart';
+import 'package:superdeck/src/export/thumbnail_service.dart';
+
+class _FakeAssetCacheStore implements AssetCacheStore {
+  final List<String> callOrder = [];
+
+  Uri? resolvedUri;
+  Uri? writeUri;
+  String? deletedKey;
+  List<int>? writtenBytes;
+
+  _FakeAssetCacheStore({this.resolvedUri, this.writeUri});
+
+  @override
+  Future<Uri?> resolve(String assetKey) async {
+    callOrder.add('resolve:$assetKey');
+    return resolvedUri;
+  }
+
+  @override
+  Future<Uri?> write(String assetKey, List<int> bytes) async {
+    callOrder.add('write:$assetKey');
+    writtenBytes = bytes;
+    return writeUri;
+  }
+
+  @override
+  Future<void> delete(String assetKey) async {
+    callOrder.add('delete:$assetKey');
+    deletedKey = assetKey;
+  }
+}
+
+class _FakeSlideCaptureService extends SlideCaptureService {
+  int captureCalls = 0;
+  final Uint8List bytes;
+
+  _FakeSlideCaptureService(this.bytes);
+
+  @override
+  Future<Uint8List> capture({
+    SlideCaptureQuality quality = SlideCaptureQuality.thumbnail,
+    required SlideConfiguration slide,
+    required BuildContext context,
+  }) async {
+    captureCalls += 1;
+    return bytes;
+  }
+}
+
+SlideConfiguration _createSlide(String key) {
+  return SlideConfiguration(
+    slideIndex: 0,
+    style: SlideStyle(),
+    slide: Slide(key: key),
+    thumbnailFile: 'thumbnail_$key.png',
+  );
+}
+
+Future<BuildContext> _pumpContext(WidgetTester tester) async {
+  final key = GlobalKey();
+  await tester.pumpWidget(
+    Directionality(
+      textDirection: TextDirection.ltr,
+      child: SizedBox(key: key),
+    ),
+  );
+  return key.currentContext!;
+}
 
 void main() {
-  group('ThumbnailService - directory issue', () {
-    late Directory tempDir;
+  group('ThumbnailService', () {
+    testWidgets('returns cache hit without capturing', (tester) async {
+      final context = await _pumpContext(tester);
+      final store = _FakeAssetCacheStore(
+        resolvedUri: Uri.parse('file:///tmp/cache-thumb.png'),
+      );
+      final capture = _FakeSlideCaptureService(Uint8List.fromList([1, 2, 3]));
+      final service = ThumbnailService(
+        cacheStore: store,
+        slideCaptureService: capture,
+      );
 
-    setUp(() async {
-      tempDir = await Directory.systemTemp.createTemp('thumbnail_test_');
+      final result = await service.generateThumbnail(
+        slide: _createSlide('intro'),
+        context: context,
+        force: false,
+      );
+
+      expect(result, equals(Uri.parse('file:///tmp/cache-thumb.png')));
+      expect(capture.captureCalls, 0);
+      expect(store.callOrder, equals(['resolve:thumbnail_intro.png']));
     });
 
-    tearDown(() async {
-      if (await tempDir.exists()) {
-        await tempDir.delete(recursive: true);
-      }
-    });
+    testWidgets('captures and writes when cache misses', (tester) async {
+      final context = await _pumpContext(tester);
+      final store = _FakeAssetCacheStore(
+        resolvedUri: null,
+        writeUri: Uri.parse('file:///tmp/new-thumb.png'),
+      );
+      final capture = _FakeSlideCaptureService(Uint8List.fromList([7, 8, 9]));
+      final service = ThumbnailService(
+        cacheStore: store,
+        slideCaptureService: capture,
+      );
 
-    test('BUG: thumbnail write fails when assets directory does not exist', () async {
-      // This test demonstrates the bug in ThumbnailService._generateThumbnail
-      // At line 75: await file.writeAsBytes(imageData);
-      //
-      // The issue: DeckService.initialize() is never called in DeckControllerBuilder,
-      // so the assets directory is never created. When ThumbnailService tries to
-      // write the thumbnail file, it fails with FileSystemException.
+      final result = await service.generateThumbnail(
+        slide: _createSlide('agenda'),
+        context: context,
+        force: false,
+      );
 
-      // Simulate the path that would be generated for a thumbnail
-      final assetsDir = Directory('${tempDir.path}/.superdeck/assets');
-      final thumbnailPath = '${assetsDir.path}/thumb-slide-abc123.png';
-
-      // The assets directory does NOT exist (simulating missing initialization)
-      expect(await assetsDir.exists(), isFalse);
-
-      // This is exactly what happens at ThumbnailService line 75
-      final file = File(thumbnailPath);
-      final imageData = [0x89, 0x50, 0x4E, 0x47]; // PNG header bytes
-
-      // BUG: This throws FileSystemException because parent dir doesn't exist
+      expect(result, equals(Uri.parse('file:///tmp/new-thumb.png')));
+      expect(capture.captureCalls, 1);
+      expect(store.writtenBytes, equals([7, 8, 9]));
       expect(
-        () async => await file.writeAsBytes(imageData),
-        throwsA(isA<FileSystemException>()),
+        store.callOrder,
+        equals(['resolve:thumbnail_agenda.png', 'write:thumbnail_agenda.png']),
       );
     });
 
-    test('FIX: thumbnail write succeeds when assets directory exists', () async {
-      // This test shows the expected behavior after the fix.
-      // When DeckService.initialize() is called, it creates the assets directory,
-      // and thumbnail generation works correctly.
+    testWidgets('force generation deletes cache before writing', (
+      tester,
+    ) async {
+      final context = await _pumpContext(tester);
+      final store = _FakeAssetCacheStore(
+        resolvedUri: Uri.parse('file:///tmp/old-thumb.png'),
+        writeUri: Uri.parse('file:///tmp/new-thumb.png'),
+      );
+      final capture = _FakeSlideCaptureService(Uint8List.fromList([4, 5, 6]));
+      final service = ThumbnailService(
+        cacheStore: store,
+        slideCaptureService: capture,
+      );
 
-      final assetsDir = Directory('${tempDir.path}/.superdeck/assets');
-      final thumbnailPath = '${assetsDir.path}/thumb-slide-abc123.png';
+      final result = await service.generateThumbnail(
+        slide: _createSlide('force'),
+        context: context,
+        force: true,
+      );
 
-      // FIX: Create the assets directory (what DeckService.initialize() does)
-      await assetsDir.create(recursive: true);
-      expect(await assetsDir.exists(), isTrue);
-
-      // Now the write succeeds
-      final file = File(thumbnailPath);
-      final imageData = [0x89, 0x50, 0x4E, 0x47]; // PNG header bytes
-
-      await file.writeAsBytes(imageData);
-
-      // Verify the file was created
-      expect(await file.exists(), isTrue);
-      expect(await file.length(), equals(4));
+      expect(result, equals(Uri.parse('file:///tmp/new-thumb.png')));
+      expect(capture.captureCalls, 1);
+      expect(store.deletedKey, equals('thumbnail_force.png'));
+      expect(
+        store.callOrder,
+        equals(['delete:thumbnail_force.png', 'write:thumbnail_force.png']),
+      );
     });
 
-    test(
-      'TDD FAILING TEST: ThumbnailService should ensure directory exists before writing',
-      () async {
-        // TDD: This test defines what the FIX should do.
-        // Currently this test FAILS because ThumbnailService doesn't ensure
-        // the parent directory exists before writing.
-        //
-        // After implementing the fix, this test should PASS.
+    testWidgets('returns null when write fails', (tester) async {
+      final context = await _pumpContext(tester);
+      final store = _FakeAssetCacheStore(resolvedUri: null, writeUri: null);
+      final capture = _FakeSlideCaptureService(Uint8List.fromList([1, 2, 3]));
+      final service = ThumbnailService(
+        cacheStore: store,
+        slideCaptureService: capture,
+      );
 
-        final assetsDir = Directory('${tempDir.path}/.superdeck/assets');
-        final thumbnailPath = '${assetsDir.path}/thumb-slide-abc123.png';
+      final result = await service.generateThumbnail(
+        slide: _createSlide('missing'),
+        context: context,
+        force: false,
+      );
 
-        // Directory does NOT exist initially
-        expect(await assetsDir.exists(), isFalse);
-
-        // Simulate what the FIXED ThumbnailService should do:
-        // 1. Check if parent directory exists
-        // 2. Create it if needed
-        // 3. Then write the file
-
-        final file = File(thumbnailPath);
-        final imageData = [0x89, 0x50, 0x4E, 0x47];
-
-        // THE FIX: Ensure parent directory exists before writing
-        // This is what ThumbnailService._generateThumbnail should do
-        final parentDir = file.parent;
-        if (!await parentDir.exists()) {
-          await parentDir.create(recursive: true);
-        }
-        await file.writeAsBytes(imageData);
-
-        // After the fix, this should work
-        expect(await file.exists(), isTrue);
-        expect(await assetsDir.exists(), isTrue);
-      },
-    );
+      expect(result, isNull);
+      expect(capture.captureCalls, 1);
+      expect(
+        store.callOrder,
+        equals([
+          'resolve:thumbnail_missing.png',
+          'write:thumbnail_missing.png',
+        ]),
+      );
+    });
   });
 }

--- a/packages/superdeck/test/utils/asset_cache_store_test.dart
+++ b/packages/superdeck/test/utils/asset_cache_store_test.dart
@@ -1,0 +1,79 @@
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:path/path.dart' as p;
+import 'package:superdeck/src/utils/asset_cache_store.dart';
+import 'package:superdeck_core/superdeck_core.dart';
+
+void main() {
+  group('Asset cache store (io)', () {
+    late Directory projectDir;
+    late DeckConfiguration configuration;
+    late AssetCacheStore store;
+    late Directory cacheDir;
+
+    const assetKey = 'thumbnail_intro.png';
+
+    setUp(() async {
+      projectDir = await Directory.systemTemp.createTemp('superdeck_asset_');
+      configuration = DeckConfiguration(projectDir: projectDir.path);
+      await configuration.assetsDir.create(recursive: true);
+
+      final cacheScope = GeneratedAsset.buildKey(
+        configuration.superdeckDir.absolute.path,
+      );
+      cacheDir = Directory(
+        p.join(
+          Directory.systemTemp.path,
+          'superdeck',
+          'asset_cache',
+          cacheScope,
+        ),
+      );
+
+      store = createAssetCacheStore(configuration: configuration);
+    });
+
+    tearDown(() async {
+      if (await cacheDir.exists()) {
+        await cacheDir.delete(recursive: true);
+      }
+      if (await projectDir.exists()) {
+        await projectDir.delete(recursive: true);
+      }
+    });
+
+    test('resolves bundled asset when app cache is empty', () async {
+      final bundledFile = File(p.join(configuration.assetsDir.path, assetKey));
+      await bundledFile.writeAsBytes([1, 2, 3]);
+
+      final resolved = await store.resolve(assetKey);
+
+      expect(resolved, bundledFile.uri);
+    });
+
+    test('resolves app cache before bundled asset', () async {
+      final bundledFile = File(p.join(configuration.assetsDir.path, assetKey));
+      await bundledFile.writeAsBytes([1, 2, 3]);
+
+      final cachedUri = await store.write(assetKey, [9, 9, 9]);
+      final resolved = await store.resolve(assetKey);
+
+      expect(cachedUri, isNotNull);
+      expect(resolved, cachedUri);
+      expect(resolved, isNot(bundledFile.uri));
+    });
+
+    test('delete removes app cache without deleting bundled asset', () async {
+      final bundledFile = File(p.join(configuration.assetsDir.path, assetKey));
+      await bundledFile.writeAsBytes([1, 2, 3]);
+      await store.write(assetKey, [9, 9, 9]);
+
+      await store.delete(assetKey);
+
+      final resolved = await store.resolve(assetKey);
+      expect(resolved, bundledFile.uri);
+      expect(await bundledFile.exists(), isTrue);
+    });
+  });
+}


### PR DESCRIPTION
This PR introduces a new AssetCacheStore abstraction in core, exports it via superdeck_core, and adds superdeck IO/web/stub cache-store implementations selected through conditional export. Thumbnail generation now resolves from app cache first, falls back to bundled assets, generates only on miss, writes only to app cache, and uses Uri-based APIs with force-delete ordering before regenerate. Slide thumbnail configuration now stores asset keys instead of absolute paths, AppShell no longer auto-regenerates thumbnails on slide changes, and AsyncThumbnail now performs targeted image cache eviction. Tests were added/updated for cache-store behavior and thumbnail flow, and validation was run with build_runner, package analyzes, and full non-interactive workspace tests.