### PR TITLE
Fix builder asset cache store integration

### DIFF
--- a/demo/macos/Flutter/GeneratedPluginRegistrant.swift
+++ b/demo/macos/Flutter/GeneratedPluginRegistrant.swift
@@ -8,7 +8,6 @@ import Foundation
 import file_picker
 import file_saver
 import file_selector_macos
-import path_provider_foundation
 import screen_retriever_macos
 import shared_preferences_foundation
 import sqflite_darwin
@@ -20,7 +19,6 @@ func RegisterGeneratedPlugins(registry: FlutterPluginRegistry) {
   FilePickerPlugin.register(with: registry.registrar(forPlugin: "FilePickerPlugin"))
   FileSaverPlugin.register(with: registry.registrar(forPlugin: "FileSaverPlugin"))
   FileSelectorPlugin.register(with: registry.registrar(forPlugin: "FileSelectorPlugin"))
-  PathProviderPlugin.register(with: registry.registrar(forPlugin: "PathProviderPlugin"))
   ScreenRetrieverMacosPlugin.register(with: registry.registrar(forPlugin: "ScreenRetrieverMacosPlugin"))
   SharedPreferencesPlugin.register(with: registry.registrar(forPlugin: "SharedPreferencesPlugin"))
   SqflitePlugin.register(with: registry.registrar(forPlugin: "SqflitePlugin"))

--- a/demo/macos/Flutter/GeneratedPluginRegistrant.swift
+++ b/demo/macos/Flutter/GeneratedPluginRegistrant.swift
@@ -8,6 +8,7 @@ import Foundation
 import file_picker
 import file_saver
 import file_selector_macos
+import path_provider_foundation
 import screen_retriever_macos
 import shared_preferences_foundation
 import sqflite_darwin
@@ -19,6 +20,7 @@ func RegisterGeneratedPlugins(registry: FlutterPluginRegistry) {
   FilePickerPlugin.register(with: registry.registrar(forPlugin: "FilePickerPlugin"))
   FileSaverPlugin.register(with: registry.registrar(forPlugin: "FileSaverPlugin"))
   FileSelectorPlugin.register(with: registry.registrar(forPlugin: "FileSelectorPlugin"))
+  PathProviderPlugin.register(with: registry.registrar(forPlugin: "PathProviderPlugin"))
   ScreenRetrieverMacosPlugin.register(with: registry.registrar(forPlugin: "ScreenRetrieverMacosPlugin"))
   SharedPreferencesPlugin.register(with: registry.registrar(forPlugin: "SharedPreferencesPlugin"))
   SqflitePlugin.register(with: registry.registrar(forPlugin: "SqflitePlugin"))

--- a/packages/builder/lib/src/assets/asset_generation_pipeline.dart
+++ b/packages/builder/lib/src/assets/asset_generation_pipeline.dart
@@ -1,8 +1,8 @@
 import 'dart:async';
-import 'dart:io';
 
 import 'package:path/path.dart' as path;
 import 'package:superdeck_builder/superdeck_builder.dart';
+import 'package:superdeck_core/asset_cache_store_io.dart';
 import 'package:superdeck_core/superdeck_core.dart';
 
 /// Result of asset generation pipeline processing on slide content.
@@ -27,13 +27,18 @@ class AssetGenerationResult {
 class AssetGenerationPipeline {
   final List<AssetGenerator> _generators;
   final DeckService _store;
+  final AssetCacheStore _cache;
   final Logger _logger = Logger('AssetGenerationPipeline');
 
   AssetGenerationPipeline({
     required List<AssetGenerator> generators,
     required DeckService store,
+    AssetCacheStore? cacheStore,
   }) : _generators = generators,
-       _store = store;
+       _store = store,
+       _cache =
+           cacheStore ??
+           IoAssetCacheStore(cacheDir: store.configuration.assetsDir);
 
   /// Processes all assets in the given slide content.
   ///
@@ -118,10 +123,9 @@ class AssetGenerationPipeline {
     final generatedAsset = generator.createAssetReference(codeBlock.content);
 
     final assetPath = _store.getGeneratedAssetPath(generatedAsset);
-    final assetFile = File(assetPath);
 
     // Check if asset already exists
-    if (await assetFile.exists()) {
+    if (await _cache.resolve(generatedAsset.fileName) != null) {
       _logger.info(
         '${generator.type} asset already exists for slide $slideIndex',
       );
@@ -135,12 +139,12 @@ class AssetGenerationPipeline {
       );
 
       // Write to disk
-      await assetFile.writeAsBytes(assetData);
+      await _cache.write(generatedAsset.fileName, assetData);
     }
 
     // Create replacement syntax with relative path from project directory
     final projectDir = _store.configuration.superdeckDir.parent.path;
-    final relativePath = path.relative(assetFile.path, from: projectDir);
+    final relativePath = path.relative(assetPath, from: projectDir);
     final replacementSyntax = '![${generator.type}_asset]($relativePath)';
 
     return (generatedAsset, replacementSyntax);

--- a/packages/builder/lib/src/assets/asset_generation_pipeline.dart
+++ b/packages/builder/lib/src/assets/asset_generation_pipeline.dart
@@ -167,14 +167,9 @@ class AssetGenerationPipeline {
     required String expectedPath,
     required String assetKey,
   }) {
-    if (cacheUri.scheme != 'file') {
-      throw StateError(
-        'Asset cache must return file URIs for key "$assetKey", '
-        'got "$cacheUri".',
-      );
-    }
-
-    final resolvedPath = path.normalize(cacheUri.toFilePath());
+    final resolvedPath = path.normalize(
+      cacheUri.scheme == 'file' ? cacheUri.toFilePath() : cacheUri.path,
+    );
     final normalizedExpectedPath = path.normalize(expectedPath);
     if (resolvedPath != normalizedExpectedPath) {
       throw StateError(

--- a/packages/builder/lib/src/assets/asset_generation_pipeline.dart
+++ b/packages/builder/lib/src/assets/asset_generation_pipeline.dart
@@ -123,23 +123,35 @@ class AssetGenerationPipeline {
     final generatedAsset = generator.createAssetReference(codeBlock.content);
 
     final assetPath = _store.getGeneratedAssetPath(generatedAsset);
-
-    // Check if asset already exists
-    if (await _cache.resolve(generatedAsset.fileName) != null) {
+    final cachedUri = await _cache.resolve(generatedAsset.fileName);
+    if (cachedUri != null) {
+      _validateCachedAssetPath(
+        cacheUri: cachedUri,
+        expectedPath: assetPath,
+        assetKey: generatedAsset.fileName,
+      );
       _logger.info(
         '${generator.type} asset already exists for slide $slideIndex',
       );
     } else {
       _logger.info('Generating ${generator.type} asset for slide $slideIndex');
 
-      // Generate the asset
       final assetData = await generator.generateAsset(
         codeBlock.content,
         assetPath,
       );
-
-      // Write to disk
-      await _cache.write(generatedAsset.fileName, assetData);
+      final writtenUri = await _cache.write(generatedAsset.fileName, assetData);
+      if (writtenUri == null) {
+        throw StateError(
+          'Failed to write ${generator.type} asset to cache for key '
+          '"${generatedAsset.fileName}".',
+        );
+      }
+      _validateCachedAssetPath(
+        cacheUri: writtenUri,
+        expectedPath: assetPath,
+        assetKey: generatedAsset.fileName,
+      );
     }
 
     // Create replacement syntax with relative path from project directory
@@ -148,6 +160,29 @@ class AssetGenerationPipeline {
     final replacementSyntax = '![${generator.type}_asset]($relativePath)';
 
     return (generatedAsset, replacementSyntax);
+  }
+
+  void _validateCachedAssetPath({
+    required Uri cacheUri,
+    required String expectedPath,
+    required String assetKey,
+  }) {
+    if (cacheUri.scheme != 'file') {
+      throw StateError(
+        'Asset cache must return file URIs for key "$assetKey", '
+        'got "$cacheUri".',
+      );
+    }
+
+    final resolvedPath = path.normalize(cacheUri.toFilePath());
+    final normalizedExpectedPath = path.normalize(expectedPath);
+    if (resolvedPath != normalizedExpectedPath) {
+      throw StateError(
+        'Asset cache path mismatch for "$assetKey". Expected '
+        '"$normalizedExpectedPath" but resolved "$resolvedPath". '
+        'Configure cacheStore to use configuration.assetsDir.',
+      );
+    }
   }
 
   /// Disposes of all generators.

--- a/packages/builder/lib/src/tasks/asset_generation_task.dart
+++ b/packages/builder/lib/src/tasks/asset_generation_task.dart
@@ -1,5 +1,6 @@
 import 'dart:async';
 
+import 'package:superdeck_core/asset_cache_store_io.dart';
 import 'package:superdeck_core/superdeck_core.dart';
 
 import '../assets/asset_generation_pipeline.dart';
@@ -18,10 +19,14 @@ final class AssetGenerationTask extends Task {
   AssetGenerationTask({
     required List<AssetGenerator> generators,
     required DeckService store,
+    AssetCacheStore? cacheStore,
     Map<String, dynamic> configuration = const {},
   }) : _pipeline = AssetGenerationPipeline(
          generators: generators,
          store: store,
+         cacheStore:
+             cacheStore ??
+             IoAssetCacheStore(cacheDir: store.configuration.assetsDir),
        ),
        super('asset_generation', configuration: configuration);
 
@@ -29,6 +34,7 @@ final class AssetGenerationTask extends Task {
   factory AssetGenerationTask.withDefaults({
     required DeckService store,
     Map<String, dynamic>? browserLaunchOptions,
+    AssetCacheStore? cacheStore,
     Map<String, dynamic> configuration = const {},
   }) {
     final generators = <AssetGenerator>[
@@ -38,6 +44,7 @@ final class AssetGenerationTask extends Task {
     return AssetGenerationTask(
       generators: generators,
       store: store,
+      cacheStore: cacheStore,
       configuration: configuration,
     );
   }

--- a/packages/builder/lib/src/tasks/asset_generation_task.dart
+++ b/packages/builder/lib/src/tasks/asset_generation_task.dart
@@ -1,6 +1,5 @@
 import 'dart:async';
 
-import 'package:superdeck_core/asset_cache_store_io.dart';
 import 'package:superdeck_core/superdeck_core.dart';
 
 import '../assets/asset_generation_pipeline.dart';
@@ -24,9 +23,7 @@ final class AssetGenerationTask extends Task {
   }) : _pipeline = AssetGenerationPipeline(
          generators: generators,
          store: store,
-         cacheStore:
-             cacheStore ??
-             IoAssetCacheStore(cacheDir: store.configuration.assetsDir),
+         cacheStore: cacheStore,
        ),
        super('asset_generation', configuration: configuration);
 

--- a/packages/builder/test/src/assets/asset_generation_pipeline_test.dart
+++ b/packages/builder/test/src/assets/asset_generation_pipeline_test.dart
@@ -10,6 +10,8 @@ import 'package:test/test.dart';
 class MockAssetGenerator implements AssetGenerator {
   final String _type;
   final List<int> _mockData;
+  int generateCallCount = 0;
+  String? lastAssetPath;
 
   MockAssetGenerator(this._type, this._mockData);
 
@@ -29,6 +31,8 @@ class MockAssetGenerator implements AssetGenerator {
 
   @override
   Future<List<int>> generateAsset(String content, String assetPath) async {
+    generateCallCount++;
+    lastAssetPath = assetPath;
     return _mockData;
   }
 
@@ -54,6 +58,39 @@ class MockDeckService extends DeckService {
     final path = '${assetsDir.path}/${asset.fileName}';
     _assetPaths[asset.fileName] = path;
     return path;
+  }
+}
+
+class InMemoryAssetCacheStore implements AssetCacheStore {
+  final Directory _cacheDir;
+  final Map<String, List<int>> _bytesByKey = {};
+
+  InMemoryAssetCacheStore(this._cacheDir);
+
+  @override
+  Future<Uri?> resolve(String assetKey) async {
+    final normalizedKey = AssetCacheStore.validateAssetKey(assetKey);
+    final bytes = _bytesByKey[normalizedKey];
+    if (bytes == null || bytes.isEmpty) {
+      return null;
+    }
+    return File('${_cacheDir.path}/$normalizedKey').uri;
+  }
+
+  @override
+  Future<Uri?> write(String assetKey, List<int> bytes) async {
+    final normalizedKey = AssetCacheStore.validateAssetKey(assetKey);
+    if (bytes.isEmpty) {
+      return null;
+    }
+    _bytesByKey[normalizedKey] = bytes;
+    return File('${_cacheDir.path}/$normalizedKey').uri;
+  }
+
+  @override
+  Future<void> delete(String assetKey) async {
+    final normalizedKey = AssetCacheStore.validateAssetKey(assetKey);
+    _bytesByKey.remove(normalizedKey);
   }
 }
 
@@ -111,6 +148,25 @@ More content.
       expect(result.generatedAssets.first.type, equals('mermaid'));
     });
 
+    test('writes generated asset bytes to expected asset path', () async {
+      const content = '''
+```mermaid
+graph TD
+  A --> B
+```
+''';
+
+      final result = await pipeline.processSlideContent(content, 0);
+      final generatedPath =
+          '${tempDir.path}/assets/${result.generatedAssets.first.fileName}';
+      final generatedFile = File(generatedPath);
+
+      expect(await generatedFile.exists(), isTrue);
+      expect(await generatedFile.readAsBytes(), equals([1, 2, 3, 4, 5]));
+      expect(mockGenerator.lastAssetPath, equals(generatedPath));
+      expect(mockGenerator.generateCallCount, equals(1));
+    });
+
     test('finds correct generator for content type', () async {
       const content = '''
 ```mermaid
@@ -154,6 +210,46 @@ graph LR
       expect(result.generatedAssets, hasLength(2));
       expect(result.updatedContent, contains('![mermaid_asset]'));
     });
+
+    test('skips regeneration when cached asset already exists', () async {
+      const content = '''
+```mermaid
+graph TD
+  A --> B
+```
+''';
+
+      await pipeline.processSlideContent(content, 0);
+      await pipeline.processSlideContent(content, 1);
+
+      expect(mockGenerator.generateCallCount, equals(1));
+    });
+
+    test(
+      'throws when cache resolves to a different path than deck assets',
+      () async {
+        final mismatchedCache = InMemoryAssetCacheStore(
+          Directory('${tempDir.path}/external-cache'),
+        );
+        final mismatchedPipeline = AssetGenerationPipeline(
+          generators: [mockGenerator],
+          store: mockStore,
+          cacheStore: mismatchedCache,
+        );
+
+        const content = '''
+```mermaid
+graph TD
+  A --> B
+```
+''';
+
+        await expectLater(
+          mismatchedPipeline.processSlideContent(content, 0),
+          throwsA(isA<Exception>()),
+        );
+      },
+    );
 
     test('dispose calls dispose on all generators', () async {
       await expectLater(pipeline.dispose(), completes);

--- a/packages/builder/test/src/assets/asset_generation_pipeline_test.dart
+++ b/packages/builder/test/src/assets/asset_generation_pipeline_test.dart
@@ -2,6 +2,7 @@ import 'dart:io';
 
 import 'package:superdeck_builder/src/assets/asset_generation_pipeline.dart';
 import 'package:superdeck_builder/src/assets/asset_generator.dart';
+import 'package:superdeck_core/asset_cache_store_io.dart';
 import 'package:superdeck_core/superdeck_core.dart';
 import 'package:test/test.dart';
 
@@ -70,6 +71,9 @@ void main() {
       pipeline = AssetGenerationPipeline(
         generators: [mockGenerator],
         store: mockStore,
+        cacheStore: IoAssetCacheStore(
+          cacheDir: Directory('${tempDir.path}/assets'),
+        ),
       );
     });
 


### PR DESCRIPTION
## Summary

This PR completes Task 4 by integrating `AssetCacheStore` into builder asset generation, while preserving `DeckService`-driven path registration and markdown relative path behavior.

## What changed

- Added cache store injection to the builder pipeline/task path:
  - `packages/builder/lib/src/assets/asset_generation_pipeline.dart`
  - `packages/builder/lib/src/tasks/asset_generation_task.dart`
- Replaced direct file cache checks/writes with `AssetCacheStore.resolve(...)` / `AssetCacheStore.write(...)`.
- Preserved `DeckService.getGeneratedAssetPath(...)` call order for cleanup tracking and markdown replacement path derivation.
- Added cache/path consistency enforcement in pipeline:
  - validates cache-resolved/written URI maps to the expected `assetsDir` path
  - throws explicit `StateError` on mismatch
- Simplified task wiring by removing duplicate fallback construction (pipeline remains the single defaulting layer).
- Expanded builder pipeline tests:
  - verifies generated bytes are written to expected asset path
  - verifies cache-hit skips regeneration
  - verifies mismatched cache path throws

## Follow-up review fixes addressed

- Fixed critical cache write vs markdown path decoupling by enforcing path consistency.
- Removed duplicate default cache store creation at task layer.
- Added concrete cache behavior assertions to tests.

## Included generated demo change

- Kept generated file update (per follow-up decision):
  - `demo/macos/Flutter/GeneratedPluginRegistrant.swift`

## Validation

Targeted checks:
- `cd packages/builder && ../../.fvm/flutter_sdk/bin/dart analyze lib/src/assets/asset_generation_pipeline.dart lib/src/tasks/asset_generation_task.dart test/src/assets/asset_generation_pipeline_test.dart`
- `cd packages/builder && ../../.fvm/flutter_sdk/bin/dart test test/src/assets/asset_generation_pipeline_test.dart`
- `cd packages/builder && ../../.fvm/flutter_sdk/bin/dart test test/src/assets/asset_generator_test.dart`

Workspace checks:
- `melos run analyze:dart` ✅
- `melos exec -- flutter test` ✅
- `melos run analyze` ❌ expected in this environment at `analyze:dcm` because DCM is not activated (Dart analysis itself passes)
