### PR TITLE
Migrate ACK enums to enumValues and camelCase docs

### DIFF
--- a/demo/showcase.md
+++ b/demo/showcase.md
@@ -26,7 +26,7 @@ SuperDeck is a presentation framework that transforms how developers create slid
 
 @column {
   flex: 2
-  align: center_left
+  align: centerLeft
 }
 ### Traditional Tools {.heading}
 
@@ -64,7 +64,7 @@ SuperDeck is a presentation framework that transforms how developers create slid
 
 @column {
   flex: 2
-  align: center_left
+  align: centerLeft
 }
 ### Hot Reload {.heading}
 
@@ -117,7 +117,7 @@ How SuperDeck organizes content on slides.
 
 @section {
   flex: 3
-  align: top_left
+  align: topLeft
 }
 
 @column {
@@ -190,7 +190,7 @@ SuperDeck uses three core block types:
 
 Each block supports:
 - `flex` - Relative sizing (default: 1)
-- `align` - Content positioning (e.g., `center`, `top_left`)
+- `align` - Content positioning (e.g., `center`, `topLeft`)
 - `scrollable` - Enable overflow scrolling
 
 ---
@@ -222,7 +222,7 @@ The CLI processes your markdown through multiple stages:
 
 @column {
   flex: 2
-  align: center_left
+  align: centerLeft
 }
 ### Getting Started {.heading}
 
@@ -317,7 +317,7 @@ style: quote
 
 @section {
   flex: 2
-  align: bottom_center
+  align: bottomCenter
 }
 # Start Building {.heading}
 ## github.com/leoafarias/superdeck {.subheading}
@@ -328,4 +328,3 @@ style: quote
   align: center
 }
 MIT License | Flutter & Dart
-

--- a/demo/slides.md
+++ b/demo/slides.md
@@ -19,7 +19,7 @@
 #### @leoafarias {.subheading}
 
 @column {
-  align: center_left
+  align: centerLeft
 }
 - Founder/CEO/CTO
 - Open Source Contributor (fvm, mix, superdeck, others..)
@@ -55,7 +55,7 @@
 @section
 
 @column {
-  align: top_center
+  align: topCenter
 }
 ```mermaid
 mindmap
@@ -102,7 +102,7 @@ SuperDeck supports flexible layouts using sections and columns.
 
 @column {
   flex: 2
-  align: center_right
+  align: centerRight
 }
 ### Two Columns {.heading}
 
@@ -476,7 +476,7 @@ A clean, typography-focused template with no chrome distractions.
 ---
 
 @section{
-  align: bottom_center
+  align: bottomCenter
   flex: 2
 }
 # Thank You {.heading}

--- a/docs/examples.mdx
+++ b/docs/examples.mdx
@@ -42,7 +42,7 @@ Use this for comparisons, pros/cons lists, or showing two related concepts side-
 
 @column {
   flex: 2
-  align: center_left
+  align: centerLeft
 }
 
 ### Generative UI
@@ -107,8 +107,8 @@ final schema = Schema.object(properties: {
     description: 'The text content to display on color palette. Format: #FF0000',
     nullable: false,
   ),
-  'font': Schema.enumString(
-    enumValues: ColorPaletteFontFamily.enumString,
+  'font': Schema.enumValues(
+    enumValues: ColorPaletteFontFamily.values,
     description: 'The font to use for the poster text.',
     nullable: false,
   ),
@@ -259,14 +259,14 @@ Column(
 @section
 
 @column {
-  align: center_right
+  align: centerRight
 }
 
 #### Leo Farias
 @leoafarias
 
 @column {
-  align: center_left
+  align: centerLeft
 }
 
 - Founder/CEO/CTO
@@ -288,7 +288,7 @@ Column(
 
 ```markdown
 @column {
-  align: center_left
+  align: centerLeft
   flex: 2
 }
 

--- a/docs/guides/markdown-authoring.mdx
+++ b/docs/guides/markdown-authoring.mdx
@@ -78,7 +78,7 @@ Renders markdown content. Most slides use one or more columns.
 ````markdown
 @column {
   flex: 2
-  align: top_left
+  align: topLeft
 }
 
 # Promise, Problem, Proof
@@ -92,7 +92,7 @@ Renders markdown content. Most slides use one or more columns.
 Use these properties on blocks:
 
 - `flex` – Relative size (default: `1`). A column with `flex: 2` takes twice the space of `flex: 1`
-- `align` – Content alignment such as `top_left`, `center`, and `bottom_right`
+- `align` – Content alignment such as `topLeft`, `center`, and `bottomRight`
 - `scrollable` – Enable scrolling for overflow content (default: `false`)
 
 For complete value definitions, see the [Markdown syntax reference](../reference/markdown-syntax).

--- a/docs/guides/superdeck-overview.mdx
+++ b/docs/guides/superdeck-overview.mdx
@@ -59,7 +59,7 @@ Build presentations with Markdown and Flutter
 - `dartpad` – embedded DartPad snippets with live editing
 - `qrcode` – generate QR codes
 
-**Alignment options**: `top_left`, `top_center`, `top_right`, `center_left`, `center`, `center_right`, `bottom_left`, `bottom_center`, `bottom_right`
+**Alignment options**: `topLeft`, `topCenter`, `topRight`, `centerLeft`, `center`, `centerRight`, `bottomLeft`, `bottomCenter`, `bottomRight`
 
 ### Custom widget support
 

--- a/docs/reference/block-types.mdx
+++ b/docs/reference/block-types.mdx
@@ -15,9 +15,9 @@ All blocks support these properties:
 **Type:** String | **Default:** `center`
 
 Controls content alignment:
-- `top_left`, `top_center`, `top_right`
-- `center_left`, `center`, `center_right`
-- `bottom_left`, `bottom_center`, `bottom_right`
+- `topLeft`, `topCenter`, `topRight`
+- `centerLeft`, `center`, `centerRight`
+- `bottomLeft`, `bottomCenter`, `bottomRight`
 
 ### `flex`
 **Type:** Number | **Default:** `1`
@@ -56,7 +56,7 @@ Arranges child blocks horizontally.
 
 ```markdown
 @section {
-  align: top_center
+  align: topCenter
   flex: 1
 }
 

--- a/docs/reference/markdown-syntax.mdx
+++ b/docs/reference/markdown-syntax.mdx
@@ -51,7 +51,7 @@ Built-in widgets (`image`, `dartpad`, `qrcode`) use the same widget syntax as `@
 
 - Type: string
 - Default: `center`
-- Values: `top_left`, `top_center`, `top_right`, `center_left`, `center`, `center_right`, `bottom_left`, `bottom_center`, `bottom_right`
+- Values: `topLeft`, `topCenter`, `topRight`, `centerLeft`, `center`, `centerRight`, `bottomLeft`, `bottomCenter`, `bottomRight`
 
 ### `scrollable`
 

--- a/docs/tutorials/block-layouts.mdx
+++ b/docs/tutorials/block-layouts.mdx
@@ -83,7 +83,7 @@ Takes 1/3 of the space
 All blocks support these properties:
 
 - **`flex`** - Relative size (default: 1)
-- **`align`** - Content alignment (center, top_left, etc.)
+- **`align`** - Content alignment (center, topLeft, etc.)
 - **`scrollable`** - Enable scrolling (default: false)
 
 ```markdown

--- a/melos.yaml
+++ b/melos.yaml
@@ -13,9 +13,9 @@ command:
     dependencies:
       collection: ^1.18.0
       mix: ^2.0.0-rc.0
-      ack: ^1.0.0-beta.4
-      ack_annotations: ^1.0.0-beta.4
-      ack_generator: ^1.0.0-beta.4
+      ack: ^1.0.0-beta.7
+      ack_annotations: ^1.0.0-beta.7
+      ack_generator: ^1.0.0-beta.7
   # publish:
     # hooks:
     #   pre: melos run gen:build

--- a/packages/builder/lib/src/parsers/raw_slide_schema.dart
+++ b/packages/builder/lib/src/parsers/raw_slide_schema.dart
@@ -4,10 +4,13 @@ import 'package:superdeck_core/superdeck_core.dart';
 part 'raw_slide_schema.g.dart';
 
 @AckType()
+final rawSlideFrontmatterSchema = Ack.object({}).passthrough();
+
+@AckType()
 final rawSlideMarkdownSchema = Ack.object({
   'key': Ack.string(),
   'content': Ack.string(),
-  'frontmatter': Ack.object({}).passthrough(),
+  'frontmatter': rawSlideFrontmatterSchema,
 });
 
 typedef RawSlideMarkdown = RawSlideMarkdownType;

--- a/packages/builder/lib/src/parsers/raw_slide_schema.g.dart
+++ b/packages/builder/lib/src/parsers/raw_slide_schema.g.dart
@@ -5,34 +5,55 @@
 // AckSchemaGenerator
 // **************************************************************************
 
-// // GENERATED CODE - DO NOT MODIFY BY HAND
-
 part of 'raw_slide_schema.dart';
+
+/// Extension type for RawSlideFrontmatter
+extension type RawSlideFrontmatterType(Map<String, Object?> _data)
+    implements Map<String, Object?> {
+  static RawSlideFrontmatterType parse(Object? data) {
+    return rawSlideFrontmatterSchema.parseAs(
+      data,
+      (validated) => RawSlideFrontmatterType(validated as Map<String, Object?>),
+    );
+  }
+
+  static SchemaResult<RawSlideFrontmatterType> safeParse(Object? data) {
+    return rawSlideFrontmatterSchema.safeParseAs(
+      data,
+      (validated) => RawSlideFrontmatterType(validated as Map<String, Object?>),
+    );
+  }
+
+  Map<String, Object?> toJson() => _data;
+
+  Map<String, Object?> get args => _data;
+}
 
 /// Extension type for RawSlideMarkdown
 extension type RawSlideMarkdownType(Map<String, Object?> _data)
     implements Map<String, Object?> {
   static RawSlideMarkdownType parse(Object? data) {
-    final validated = rawSlideMarkdownSchema.parse(data);
-    return RawSlideMarkdownType(validated as Map<String, Object?>);
+    return rawSlideMarkdownSchema.parseAs(
+      data,
+      (validated) => RawSlideMarkdownType(validated as Map<String, Object?>),
+    );
   }
 
   static SchemaResult<RawSlideMarkdownType> safeParse(Object? data) {
-    final result = rawSlideMarkdownSchema.safeParse(data);
-    return result.match(
-      onOk: (validated) => SchemaResult.ok(
-        RawSlideMarkdownType(validated as Map<String, Object?>),
-      ),
-      onFail: (error) => SchemaResult.fail(error),
+    return rawSlideMarkdownSchema.safeParseAs(
+      data,
+      (validated) => RawSlideMarkdownType(validated as Map<String, Object?>),
     );
   }
+
+  Map<String, Object?> toJson() => _data;
 
   String get key => _data['key'] as String;
 
   String get content => _data['content'] as String;
 
-  Map<String, Object?> get frontmatter =>
-      _data['frontmatter'] as Map<String, Object?>;
+  RawSlideFrontmatterType get frontmatter =>
+      RawSlideFrontmatterType(_data['frontmatter'] as Map<String, Object?>);
 
   RawSlideMarkdownType copyWith({
     String? key,

--- a/packages/builder/pubspec.yaml
+++ b/packages/builder/pubspec.yaml
@@ -17,11 +17,11 @@ dependencies:
   puppeteer: ^3.17.0
   crypto: ^3.0.6
   markdown: ^7.3.0
-  ack_annotations: ^1.0.0-beta.4
+  ack_annotations: ^1.0.0-beta.7
 
 dev_dependencies:
   lints: ^5.0.0
   test: ^1.25.8
   dart_code_metrics_presets: ^2.19.0
   build_runner: ^2.5.4
-  ack_generator: ^1.0.0-beta.4
+  ack_generator: ^1.0.0-beta.7

--- a/packages/builder/test/src/parsers/section_parser_test.dart
+++ b/packages/builder/test/src/parsers/section_parser_test.dart
@@ -185,7 +185,7 @@ Header content column 2.
         );
       });
 
-      test('Section with columns and alignment attribute in snake case', () {
+      test('Section with columns and alignment attribute', () {
         const markdown = '''
 @section
 @column{
@@ -194,7 +194,7 @@ Header content column 2.
 Body content column 1.
 
 @column{
-      align: bottom_right
+      align: bottomRight
 }
 Body content column 2.
 ''';
@@ -211,45 +211,42 @@ Body content column 2.
         );
       });
 
-      test(
-        'Section with columns, flex, and alignment attributes in snake case',
-        () {
-          const markdown = '''
+      test('Section with columns, flex, and alignment attributes', () {
+        const markdown = '''
 @section
 @column{
   flex: 3 
-  align: top_left
+  align: topLeft
 }
 Footer content column 1.
 @column{
   flex: 1
-  align: center_right
+  align: centerRight
 }
 Footer content column 2.
 ''';
 
-          final sections = sectionParser.parse(markdown);
-          expect(sections[0].blocks.length, equals(2));
+        final sections = sectionParser.parse(markdown);
+        expect(sections[0].blocks.length, equals(2));
 
-          expect(
-            sections[0].blocks[0].content.trim(),
-            'Footer content column 1.',
-          );
-          expect(
-            sections[0].blocks[1].content.trim(),
-            'Footer content column 2.',
-          );
+        expect(
+          sections[0].blocks[0].content.trim(),
+          'Footer content column 1.',
+        );
+        expect(
+          sections[0].blocks[1].content.trim(),
+          'Footer content column 2.',
+        );
 
-          expect(sections[0].blocks[0].flex, equals(3));
-          expect(sections[0].blocks[0].align, equals(ContentAlignment.topLeft));
+        expect(sections[0].blocks[0].flex, equals(3));
+        expect(sections[0].blocks[0].align, equals(ContentAlignment.topLeft));
 
-          expect(sections[0].blocks[1].flex, equals(1));
-          expect(
-            sections[0].blocks[1].align,
-            equals(ContentAlignment.centerRight),
-          );
-        },
-      );
+        expect(sections[0].blocks[1].flex, equals(1));
+        expect(
+          sections[0].blocks[1].align,
+          equals(ContentAlignment.centerRight),
+        );
+      });
 
       test('Sections with columns and attributes', () {
         const markdown = '''
@@ -263,20 +260,20 @@ Header content.
 @section
 @column{
     flex: 2
-    align: center_left
+    align: centerLeft
 }
 Body content column 1.
 
 @column{
     flex: 1
-    align: center_right
+    align: centerRight
 }
 Body content column 2.
 
 @section
 @column{
     flex: 1
-    align: bottom_center
+    align: bottomCenter
 }
 Footer content.
 
@@ -323,7 +320,7 @@ Footer content.
 Header content.
 
 @section{
-  align: top_left
+  align: topLeft
   flex: 2
 }
 @column{
@@ -332,10 +329,10 @@ Header content.
 Body content.
 
 @section{
-  align: bottom_right
+  align: bottomRight
   flex: 1
 }
-@column{ align: bottom_right}
+@column{ align: bottomRight}
 Footer content.
 
 ''';

--- a/packages/builder/test/src/slide_processor_test.dart
+++ b/packages/builder/test/src/slide_processor_test.dart
@@ -712,7 +712,7 @@ Column 1 content
 
 @column{
   flex: 2
-  align: top_left
+  align: topLeft
 }
 Column 2 content
 

--- a/packages/cli/lib/src/commands/setup_command.dart
+++ b/packages/cli/lib/src/commands/setup_command.dart
@@ -68,7 +68,7 @@ Your awesome slides start here!
 - Add more items here
 
 @column {
-  align: center_right
+  align: centerRight
 }
 
 This content appears in the right column.

--- a/packages/core/lib/src/models/block_model.dart
+++ b/packages/core/lib/src/models/block_model.dart
@@ -262,10 +262,9 @@ enum DartPadTheme {
   String toJson() => name;
 
   static DartPadTheme fromJson(String value) {
-    // Support both camelCase and snake_case (though this enum is all lowercase)
-    final normalized = value.replaceAll('_', '');
+    final normalized = value.toLowerCase();
     return DartPadTheme.values.firstWhere(
-      (e) => e.name.toLowerCase() == normalized.toLowerCase(),
+      (e) => e.name.toLowerCase() == normalized,
       orElse: () => throw ArgumentError('Invalid DartPadTheme: $value'),
     );
   }
@@ -285,10 +284,9 @@ enum ImageFit {
   String toJson() => name;
 
   static ImageFit fromJson(String value) {
-    // Support both camelCase and snake_case
-    final normalized = value.replaceAll('_', '');
+    final normalized = value.toLowerCase();
     return ImageFit.values.firstWhere(
-      (e) => e.name.toLowerCase() == normalized.toLowerCase(),
+      (e) => e.name.toLowerCase() == normalized,
       orElse: () => throw ArgumentError('Invalid ImageFit: $value'),
     );
   }
@@ -409,10 +407,9 @@ enum ContentAlignment {
   String toJson() => name;
 
   static ContentAlignment fromJson(String value) {
-    // Support both camelCase and snake_case
-    final normalized = value.replaceAll('_', '');
+    final normalized = value.toLowerCase();
     return ContentAlignment.values.firstWhere(
-      (e) => e.name.toLowerCase() == normalized.toLowerCase(),
+      (e) => e.name.toLowerCase() == normalized,
       orElse: () => throw ArgumentError('Invalid ContentAlignment: $value'),
     );
   }

--- a/packages/core/lib/src/utils/extensions.dart
+++ b/packages/core/lib/src/utils/extensions.dart
@@ -35,24 +35,9 @@ extension DirectoryX on Directory {
   }
 }
 
-/// ACK (Schema Validation) helper function for enums
-StringSchema ackEnum(List<Enum> values) {
-  return Ack.string().enumString(
-    values.map((e) {
-      // Convert enum name to snake_case
-      final name = e.name;
-      return name
-          .replaceAll(RegExp(r'\s+'), '_')
-          .replaceAllMapped(
-            RegExp(
-              r'[A-Z]{2,}(?=[A-Z][a-z]+[0-9]*|\b)|[A-Z]?[a-z]+[0-9]*|[A-Z]|[0-9]+',
-            ),
-            (match) => "${match.group(0)!.toLowerCase()}_",
-          )
-          .replaceAll(RegExp(r'(_)\1+'), '_')
-          .replaceAll(RegExp(r'^_|_$'), '');
-    }).toList(),
-  );
+/// ACK (Schema Validation) helper function for enums.
+EnumSchema<T> ackEnum<T extends Enum>(List<T> values) {
+  return Ack.enumValues(values);
 }
 
 /// Extension on StringSchema for hex color validation

--- a/packages/core/pubspec.yaml
+++ b/packages/core/pubspec.yaml
@@ -14,7 +14,7 @@ dependencies:
   collection: ^1.18.0
   path: ^1.9.0
   meta: ^1.15.0
-  ack: ^1.0.0-beta.4
+  ack: ^1.0.0-beta.7
   markdown: ^7.3.0
   logging: ^1.3.0
   crypto: ^3.0.6

--- a/packages/core/test/src/models/block_model_test.dart
+++ b/packages/core/test/src/models/block_model_test.dart
@@ -76,16 +76,25 @@ void main() {
           expect(ImageFit.fromJson('scaleDown'), ImageFit.scaleDown);
         });
 
-        test('parses snake_case values', () {
-          expect(ImageFit.fromJson('fit_width'), ImageFit.fitWidth);
-          expect(ImageFit.fromJson('fit_height'), ImageFit.fitHeight);
-          expect(ImageFit.fromJson('scale_down'), ImageFit.scaleDown);
+        test('throws for underscored values', () {
+          expect(
+            () => ImageFit.fromJson('fit_width'),
+            throwsA(isA<ArgumentError>()),
+          );
+          expect(
+            () => ImageFit.fromJson('fit_height'),
+            throwsA(isA<ArgumentError>()),
+          );
+          expect(
+            () => ImageFit.fromJson('scale_down'),
+            throwsA(isA<ArgumentError>()),
+          );
         });
 
         test('parses case-insensitively', () {
           expect(ImageFit.fromJson('FILL'), ImageFit.fill);
           expect(ImageFit.fromJson('Cover'), ImageFit.cover);
-          expect(ImageFit.fromJson('FIT_WIDTH'), ImageFit.fitWidth);
+          expect(ImageFit.fromJson('FITWIDTH'), ImageFit.fitWidth);
         });
 
         test('throws for invalid value', () {
@@ -101,13 +110,16 @@ void main() {
           expect(ImageFit.schema.safeParse('fill').isOk, isTrue);
           expect(ImageFit.schema.safeParse('contain').isOk, isTrue);
           expect(ImageFit.schema.safeParse('cover').isOk, isTrue);
+          expect(ImageFit.schema.safeParse('fitWidth').isOk, isTrue);
+          expect(ImageFit.schema.safeParse('fitHeight').isOk, isTrue);
           expect(ImageFit.schema.safeParse('none').isOk, isTrue);
+          expect(ImageFit.schema.safeParse('scaleDown').isOk, isTrue);
         });
 
-        test('validates snake_case values', () {
-          expect(ImageFit.schema.safeParse('fit_width').isOk, isTrue);
-          expect(ImageFit.schema.safeParse('fit_height').isOk, isTrue);
-          expect(ImageFit.schema.safeParse('scale_down').isOk, isTrue);
+        test('rejects underscored values', () {
+          expect(ImageFit.schema.safeParse('fit_width').isOk, isFalse);
+          expect(ImageFit.schema.safeParse('fit_height').isOk, isFalse);
+          expect(ImageFit.schema.safeParse('scale_down').isOk, isFalse);
         });
 
         test('rejects invalid values', () {
@@ -169,22 +181,22 @@ void main() {
           );
         });
 
-        test('parses snake_case values', () {
+        test('throws for underscored values', () {
           expect(
-            ContentAlignment.fromJson('top_left'),
-            ContentAlignment.topLeft,
+            () => ContentAlignment.fromJson('top_left'),
+            throwsA(isA<ArgumentError>()),
           );
           expect(
-            ContentAlignment.fromJson('top_center'),
-            ContentAlignment.topCenter,
+            () => ContentAlignment.fromJson('top_center'),
+            throwsA(isA<ArgumentError>()),
           );
           expect(
-            ContentAlignment.fromJson('center_left'),
-            ContentAlignment.centerLeft,
+            () => ContentAlignment.fromJson('center_left'),
+            throwsA(isA<ArgumentError>()),
           );
           expect(
-            ContentAlignment.fromJson('bottom_right'),
-            ContentAlignment.bottomRight,
+            () => ContentAlignment.fromJson('bottom_right'),
+            throwsA(isA<ArgumentError>()),
           );
         });
 
@@ -195,7 +207,7 @@ void main() {
           );
           expect(ContentAlignment.fromJson('Center'), ContentAlignment.center);
           expect(
-            ContentAlignment.fromJson('BOTTOM_CENTER'),
+            ContentAlignment.fromJson('BOTTOMCENTER'),
             ContentAlignment.bottomCenter,
           );
         });
@@ -210,16 +222,30 @@ void main() {
 
       group('schema', () {
         test('validates all enum values', () {
+          expect(ContentAlignment.schema.safeParse('topLeft').isOk, isTrue);
+          expect(ContentAlignment.schema.safeParse('topCenter').isOk, isTrue);
+          expect(ContentAlignment.schema.safeParse('topRight').isOk, isTrue);
+          expect(ContentAlignment.schema.safeParse('centerLeft').isOk, isTrue);
           expect(ContentAlignment.schema.safeParse('center').isOk, isTrue);
+          expect(ContentAlignment.schema.safeParse('centerRight').isOk, isTrue);
+          expect(ContentAlignment.schema.safeParse('bottomLeft').isOk, isTrue);
+          expect(
+            ContentAlignment.schema.safeParse('bottomCenter').isOk,
+            isTrue,
+          );
+          expect(ContentAlignment.schema.safeParse('bottomRight').isOk, isTrue);
         });
 
-        test('validates snake_case values', () {
-          expect(ContentAlignment.schema.safeParse('top_left').isOk, isTrue);
-          expect(ContentAlignment.schema.safeParse('top_center').isOk, isTrue);
-          expect(ContentAlignment.schema.safeParse('center_left').isOk, isTrue);
+        test('rejects underscored values', () {
+          expect(ContentAlignment.schema.safeParse('top_left').isOk, isFalse);
+          expect(ContentAlignment.schema.safeParse('top_center').isOk, isFalse);
+          expect(
+            ContentAlignment.schema.safeParse('center_left').isOk,
+            isFalse,
+          );
           expect(
             ContentAlignment.schema.safeParse('bottom_right').isOk,
-            isTrue,
+            isFalse,
           );
         });
 

--- a/packages/core/test/src/utils/extensions_test.dart
+++ b/packages/core/test/src/utils/extensions_test.dart
@@ -202,7 +202,7 @@ line3''';
     });
 
     group('ackEnum', () {
-      test('converts simple enum names to snake_case', () {
+      test('validates simple enum names', () {
         final schema = ackEnum(SimpleEnum.values);
 
         expect(schema.safeParse('one').isOk, isTrue);
@@ -210,12 +210,12 @@ line3''';
         expect(schema.safeParse('three').isOk, isTrue);
       });
 
-      test('converts camelCase enum names to snake_case', () {
+      test('validates camelCase enum names', () {
         final schema = ackEnum(CamelCaseEnum.values);
 
-        expect(schema.safeParse('first_value').isOk, isTrue);
-        expect(schema.safeParse('second_value').isOk, isTrue);
-        expect(schema.safeParse('third_value_here').isOk, isTrue);
+        expect(schema.safeParse('firstValue').isOk, isTrue);
+        expect(schema.safeParse('secondValue').isOk, isTrue);
+        expect(schema.safeParse('thirdValueHere').isOk, isTrue);
       });
 
       test('handles single word enums', () {
@@ -233,12 +233,11 @@ line3''';
         expect(schema.safeParse('').isOk, isFalse);
       });
 
-      test('handles uppercase abbreviations', () {
+      test('validates abbreviation enum names', () {
         final schema = ackEnum(AbbreviationEnum.values);
 
-        // URLParser becomes url_parser
-        expect(schema.safeParse('url_parser').isOk, isTrue);
-        expect(schema.safeParse('html_element').isOk, isTrue);
+        expect(schema.safeParse('urlParser').isOk, isTrue);
+        expect(schema.safeParse('htmlElement').isOk, isTrue);
       });
 
       test('handles numeric suffixes', () {

--- a/packages/superdeck/lib/src/styling/schema/style_schemas.dart
+++ b/packages/superdeck/lib/src/styling/schema/style_schemas.dart
@@ -13,6 +13,22 @@ import '../components/slide.dart';
 
 typedef _JsonMap = Map<String, Object?>;
 
+enum _FontWeightToken {
+  normal,
+  bold,
+  w100,
+  w200,
+  w300,
+  w400,
+  w500,
+  w600,
+  w700,
+  w800,
+  w900,
+}
+
+enum _TextDecorationToken { none, underline, lineThrough, overline }
+
 /// Result type from parsing styles.yaml.
 /// Produced directly by [StyleSchemas.styleConfigSchema.parse()].
 typedef StyleConfigResult = ({
@@ -49,34 +65,25 @@ typedef StyleConfigResult = ({
 class StyleSchemas {
   StyleSchemas._();
 
-  static const _fontWeights = <String, FontWeight>{
-    'normal': FontWeight.normal,
-    'bold': FontWeight.bold,
-    'w100': FontWeight.w100,
-    'w200': FontWeight.w200,
-    'w300': FontWeight.w300,
-    'w400': FontWeight.w400,
-    'w500': FontWeight.w500,
-    'w600': FontWeight.w600,
-    'w700': FontWeight.w700,
-    'w800': FontWeight.w800,
-    'w900': FontWeight.w900,
+  static const _fontWeights = <_FontWeightToken, FontWeight>{
+    _FontWeightToken.normal: FontWeight.normal,
+    _FontWeightToken.bold: FontWeight.bold,
+    _FontWeightToken.w100: FontWeight.w100,
+    _FontWeightToken.w200: FontWeight.w200,
+    _FontWeightToken.w300: FontWeight.w300,
+    _FontWeightToken.w400: FontWeight.w400,
+    _FontWeightToken.w500: FontWeight.w500,
+    _FontWeightToken.w600: FontWeight.w600,
+    _FontWeightToken.w700: FontWeight.w700,
+    _FontWeightToken.w800: FontWeight.w800,
+    _FontWeightToken.w900: FontWeight.w900,
   };
 
-  static const _textDecorations = <String, TextDecoration>{
-    'none': TextDecoration.none,
-    'underline': TextDecoration.underline,
-    'lineThrough': TextDecoration.lineThrough,
-    'overline': TextDecoration.overline,
-  };
-
-  static const _wrapAlignments = <String, WrapAlignment>{
-    'start': WrapAlignment.start,
-    'end': WrapAlignment.end,
-    'center': WrapAlignment.center,
-    'spaceBetween': WrapAlignment.spaceBetween,
-    'spaceAround': WrapAlignment.spaceAround,
-    'spaceEvenly': WrapAlignment.spaceEvenly,
+  static const _textDecorations = <_TextDecorationToken, TextDecoration>{
+    _TextDecorationToken.none: TextDecoration.none,
+    _TextDecorationToken.underline: TextDecoration.underline,
+    _TextDecorationToken.lineThrough: TextDecoration.lineThrough,
+    _TextDecorationToken.overline: TextDecoration.overline,
   };
 
   static final _baseTextCoreProperties = <String, AckSchema<Object>>{
@@ -103,22 +110,19 @@ class StyleSchemas {
       .optional();
 
   /// Validates font weight values and transforms to [FontWeight].
-  static final fontWeightSchema = Ack.string()
-      .enumString(_fontWeights.keys.toList())
-      .transform(_stringToFontWeight)
-      .optional();
+  static final fontWeightSchema = Ack.enumValues(
+    _FontWeightToken.values,
+  ).transform(_fontWeightToFlutter).optional();
 
   /// Validates text decoration values and transforms to [TextDecoration].
-  static final textDecorationSchema = Ack.string()
-      .enumString(_textDecorations.keys.toList())
-      .transform(_stringToTextDecoration)
-      .optional();
+  static final textDecorationSchema = Ack.enumValues(
+    _TextDecorationToken.values,
+  ).transform(_textDecorationToFlutter).optional();
 
   /// Validates wrap alignment values and transforms to [WrapAlignment].
-  static final alignmentSchema = Ack.string()
-      .enumString(_wrapAlignments.keys.toList())
-      .transform(_stringToWrapAlignment)
-      .optional();
+  static final alignmentSchema = Ack.enumValues(
+    WrapAlignment.values,
+  ).optional();
 
   // ===========================================================================
   // LEVEL 2: Padding Schema WITH TRANSFORM
@@ -360,19 +364,14 @@ class StyleSchemas {
     return Color(int.parse(hex, radix: 16));
   }
 
-  /// Transforms font weight string to [FontWeight].
-  static FontWeight _stringToFontWeight(String? value) {
+  /// Transforms font weight token to [FontWeight].
+  static FontWeight _fontWeightToFlutter(_FontWeightToken? value) {
     return _fontWeights[value] ?? FontWeight.normal;
   }
 
-  /// Transforms text decoration string to [TextDecoration].
-  static TextDecoration _stringToTextDecoration(String? value) {
+  /// Transforms text decoration token to [TextDecoration].
+  static TextDecoration _textDecorationToFlutter(_TextDecorationToken? value) {
     return _textDecorations[value] ?? TextDecoration.none;
-  }
-
-  /// Transforms wrap alignment string to [WrapAlignment].
-  static WrapAlignment _stringToWrapAlignment(String? value) {
-    return _wrapAlignments[value] ?? WrapAlignment.start;
   }
 
   // ---------------------------------------------------------------------------

--- a/packages/superdeck/lib/src/widgets/qr_code_widget.dart
+++ b/packages/superdeck/lib/src/widgets/qr_code_widget.dart
@@ -5,6 +5,8 @@ import 'package:superdeck_core/superdeck_core.dart';
 import '../deck/widget_definition.dart';
 import '../utils/converters.dart';
 
+enum _QrErrorCorrectionToken { low, l, medium, m, high, q, highest, h }
+
 /// Strongly-typed data transfer object for QR code widget.
 class QrCodeDto {
   /// The data to encode in the QR code.
@@ -37,23 +39,26 @@ class QrCodeDto {
       message: 'QR code text must be less than 1000 characters',
     ),
     'size': Ack.double().min(1).max(1000).nullable().optional(),
-    'errorCorrection': Ack.string()
-        .enumString(['low', 'l', 'medium', 'm', 'high', 'q', 'highest', 'h'])
-        .nullable()
-        .optional(),
+    'errorCorrection': Ack.enumValues(
+      _QrErrorCorrectionToken.values,
+    ).nullable().optional(),
     'backgroundColor': Ack.string().nullable().optional().hexColor(),
     'foregroundColor': Ack.string().nullable().optional().hexColor(),
   });
 
   /// Parses and validates raw map into typed QrCodeDto.
   static QrCodeDto parse(Map<String, Object?> map) {
-    schema.parse(map); // Validate first
+    final parsed = schema.parse(map)!;
+    final errorCorrection =
+        parsed['errorCorrection'] as _QrErrorCorrectionToken? ??
+        _QrErrorCorrectionToken.medium;
+
     return QrCodeDto(
-      text: map['text'] as String,
-      size: (map['size'] as num?)?.toDouble() ?? 200.0,
-      errorCorrection: map['errorCorrection'] as String? ?? 'medium',
-      backgroundColor: map['backgroundColor'] as String?,
-      foregroundColor: map['foregroundColor'] as String?,
+      text: parsed['text'] as String,
+      size: (parsed['size'] as num?)?.toDouble() ?? 200.0,
+      errorCorrection: errorCorrection.name,
+      backgroundColor: parsed['backgroundColor'] as String?,
+      foregroundColor: parsed['foregroundColor'] as String?,
     );
   }
 }

--- a/packages/superdeck/test/fixtures/deck_reference.json
+++ b/packages/superdeck/test/fixtures/deck_reference.json
@@ -64,7 +64,7 @@
       "options": {
         "style": "quote"
       },
-      "markdown": "{@section}\n{@column align: bottom_right flex: 3}\n# This presentation will be great\n\n{@column}\n\n{@section}\n\n\n{@column }\n{@column flex: 2 align: top_right}\n> Create your Flutter presentations faster and easier than ever.\n> You can quote me on that\n> ### Leo",
+      "markdown": "{@section}\n{@column align: bottomRight flex: 3}\n# This presentation will be great\n\n{@column}\n\n{@section}\n\n\n{@column }\n{@column flex: 2 align: topRight}\n> Create your Flutter presentations faster and easier than ever.\n> You can quote me on that\n> ### Leo",
       "sections": [
         {
           "options": null,
@@ -73,7 +73,7 @@
               "content": "\n# This presentation will be great",
               "options": {
                 "flex": 3,
-                "align": "bottom_right"
+                "align": "bottomRight"
               },
               "type": "column"
             },
@@ -96,7 +96,7 @@
               "content": "\n> Create your Flutter presentations faster and easier than ever.\n> You can quote me on that\n> ### Leo",
               "options": {
                 "flex": 2,
-                "align": "top_right"
+                "align": "topRight"
               },
               "type": "column"
             }
@@ -109,7 +109,7 @@
       "options": {
         "style": "show_sections"
       },
-      "markdown": "{@section}\n{@image src: https://picsum.photos/1200/1200?waves align: top_left fit: cover}\n\n{@section flex: 2}\n{@column flex: 2}\n# Two Column HGoes here\n\nThis is a two-column layout. You can use it to compare two different concepts or ideas.\n\n\n{@column}\n\n### Section Options\n\nEasily customize the content of each section to suit your needs.\n\nUse front matter to define the layout of each section",
+      "markdown": "{@section}\n{@image src: https://picsum.photos/1200/1200?waves align: topLeft fit: cover}\n\n{@section flex: 2}\n{@column flex: 2}\n# Two Column HGoes here\n\nThis is a two-column layout. You can use it to compare two different concepts or ideas.\n\n\n{@column}\n\n### Section Options\n\nEasily customize the content of each section to suit your needs.\n\nUse front matter to define the layout of each section",
       "sections": [
         {
           "options": null,
@@ -118,7 +118,7 @@
               "options": {
                 "src": "https://picsum.photos/1200/1200?waves",
                 "fit": "cover",
-                "align": "top_left",
+                "align": "topLeft",
                 "type": "image"
               },
               "content": "",
@@ -152,7 +152,7 @@
       "options": {
         "style": "show_sections"
       },
-      "markdown": "{@section}\n{@column align: bottom_right}\n\n## First\n\n{@column}  \n\n\n## Header\n\n{@section flex: 2}\n\n### Left Section\nEasily customize the content of each section to suit your needs.\n\nUse front matter to define the layout of each section\n\n{@column}\n\n#### Section Options\n\n```yaml\nsections:\n  left:\n    alignment: bottom_right\n    flex: 2\n  right:\n    alignment: bottom_left\n  header:\n    alignment: bottom_left\n```",
+      "markdown": "{@section}\n{@column align: bottomRight}\n\n## First\n\n{@column}  \n\n\n## Header\n\n{@section flex: 2}\n\n### Left Section\nEasily customize the content of each section to suit your needs.\n\nUse front matter to define the layout of each section\n\n{@column}\n\n#### Section Options\n\n```yaml\nsections:\n  left:\n    alignment: bottomRight\n    flex: 2\n  right:\n    alignment: bottomLeft\n  header:\n    alignment: bottomLeft\n```",
       "sections": [
         {
           "options": null,
@@ -160,7 +160,7 @@
             {
               "content": "\n## First",
               "options": {
-                "align": "bottom_right"
+                "align": "bottomRight"
               },
               "type": "column"
             },
@@ -181,7 +181,7 @@
               "type": "column"
             },
             {
-              "content": "\n#### Section Options\n```yaml\nsections:\n  left:\n    alignment: bottom_right\n    flex: 2\n  right:\n    alignment: bottom_left\n  header:\n    alignment: bottom_left\n```",
+              "content": "\n#### Section Options\n```yaml\nsections:\n  left:\n    alignment: bottomRight\n    flex: 2\n  right:\n    alignment: bottomLeft\n  header:\n    alignment: bottomLeft\n```",
               "options": null,
               "type": "column"
             }


### PR DESCRIPTION
Upgrades ack, ack_annotations, and ack_generator to 1.0.0-beta.7 in melos, core, and builder. Replaces enumString-based schemas with Ack.enumValues across core helpers, superdeck style schemas, and QR widget validation/parsing. Standardizes enum literals to camelCase in builder and cli fixtures/tests, demo decks, docs references, and superdeck fixture JSON, and updates core tests to assert underscored values are rejected. Validated with fvm dart analyze and fvm dart test for the touched core files.