### PR TITLE
Consolidate YAML map parsing

### DIFF
--- a/packages/cli/lib/src/commands/setup/setup_support.dart
+++ b/packages/cli/lib/src/commands/setup/setup_support.dart
@@ -53,7 +53,9 @@ Future<void> applySetup(Directory projectDir, Logger logger) async {
   final flutterDependency = dependencies is Map
       ? dependencies['flutter']
       : null;
-  if (flutterDependency is! Map || flutterDependency['sdk'] != 'flutter') {
+  final isFlutterApp =
+      flutterDependency is Map && flutterDependency['sdk'] == 'flutter';
+  if (!isFlutterApp) {
     throw FileSystemException(
       'Failed to configure SuperDeck: pubspec.yaml does not declare a '
       'Flutter SDK dependency. SuperDeck requires a Flutter app.',

--- a/packages/cli/lib/src/commands/setup/setup_support.dart
+++ b/packages/cli/lib/src/commands/setup/setup_support.dart
@@ -2,7 +2,7 @@ import 'dart:io';
 
 import 'package:mason_logger/mason_logger.dart';
 import 'package:path/path.dart' as path;
-import 'package:yaml/yaml.dart';
+import 'package:superdeck_core/superdeck_core.dart';
 import 'package:yaml_writer/yaml_writer.dart';
 
 import '../../utils/constants.dart';
@@ -48,12 +48,12 @@ Future<void> applySetup(Directory projectDir, Logger logger) async {
   }
 
   final pubspecContents = await pubspecFile.readAsString();
-  final pubspec = loadYaml(pubspecContents);
-  if (pubspec is! Map ||
-      pubspec['dependencies'] is! Map ||
-      (pubspec['dependencies'] as Map)['flutter'] is! Map ||
-      ((pubspec['dependencies'] as Map)['flutter'] as Map)['sdk'] !=
-          'flutter') {
+  final pubspec = parseYamlMap(pubspecContents, sourceLabel: 'pubspec.yaml');
+  final dependencies = pubspec['dependencies'];
+  final flutterDependency = dependencies is Map
+      ? dependencies['flutter']
+      : null;
+  if (flutterDependency is! Map || flutterDependency['sdk'] != 'flutter') {
     throw FileSystemException(
       'Failed to configure SuperDeck: pubspec.yaml does not declare a '
       'Flutter SDK dependency. SuperDeck requires a Flutter app.',
@@ -86,7 +86,7 @@ Future<void> applySetup(Directory projectDir, Logger logger) async {
 }
 
 String patchSetupPubspec(String pubspecContents) {
-  final pubspec = _loadYamlMap(pubspecContents);
+  final pubspec = parseYamlMap(pubspecContents, sourceLabel: 'pubspec.yaml');
   final dependencies = _mutableMap(pubspec['dependencies']);
   final devDependencies = _mutableMap(pubspec['dev_dependencies']);
   final flutter = _mutableMap(pubspec['flutter']);
@@ -178,42 +178,9 @@ String _insertBeforeClosingTag(
   return html.replaceRange(match.start, match.start, '$insertion\n');
 }
 
-Map<String, Object?> _loadYamlMap(String contents) {
-  final yaml = loadYaml(contents);
-  if (yaml is! Map<Object?, Object?>) {
-    throw const FormatException(
-      'Expected generated YAML content to have a top-level map.',
-    );
-  }
-  return _stringKeyedMap(yaml);
-}
-
-Map<String, Object?> _stringKeyedMap(Map<Object?, Object?> source) {
-  return source.map((key, value) {
-    final stringKey = key?.toString();
-    if (stringKey == null) {
-      throw const FormatException('Encountered a null YAML key.');
-    }
-    return MapEntry(stringKey, _normalizeYamlValue(value));
-  });
-}
-
-Object? _normalizeYamlValue(Object? value) {
-  if (value is Map<Object?, Object?>) {
-    return _stringKeyedMap(value);
-  }
-  if (value is List) {
-    return value.map(_normalizeYamlValue).toList();
-  }
-  return value;
-}
-
 Map<String, Object?> _mutableMap(Object? value) {
-  if (value is Map<String, Object?>) {
+  if (value is Map) {
     return Map<String, Object?>.from(value);
-  }
-  if (value is Map<Object?, Object?>) {
-    return _stringKeyedMap(value);
   }
   return <String, Object?>{};
 }

--- a/packages/cli/lib/src/utils/update_pubspec.dart
+++ b/packages/cli/lib/src/utils/update_pubspec.dart
@@ -1,13 +1,12 @@
 import 'package:path/path.dart' as p;
 import 'package:superdeck_core/superdeck_core.dart';
-import 'package:yaml/yaml.dart';
 import 'package:yaml_writer/yaml_writer.dart';
 
 /// Updates the 'assets' section of a pubspec.yaml with workspace paths.
 String updatePubspecAssets(DeckWorkspace workspace, String pubspecContents) {
-  final parsedYaml = _loadPubspecMap(pubspecContents);
-  final flutterSection = _stringKeyedMap(
-    parsedYaml['flutter'] as Map? ?? const <String, dynamic>{},
+  final parsedYaml = parseYamlMap(pubspecContents, sourceLabel: 'pubspec.yaml');
+  final flutterSection = Map<String, Object?>.from(
+    parsedYaml['flutter'] as Map? ?? const <String, Object?>{},
   );
 
   final assets = List<String>.from(
@@ -38,41 +37,4 @@ String updatePubspecAssets(DeckWorkspace workspace, String pubspecContents) {
   final updatedYaml = Map.of(parsedYaml)..['flutter'] = flutterSection;
 
   return YamlWriter(allowUnquotedStrings: true).write(updatedYaml);
-}
-
-Map<String, Object?> _loadPubspecMap(String pubspecContents) {
-  Object? yaml;
-  try {
-    yaml = loadYaml(pubspecContents);
-  } on YamlException catch (error, stackTrace) {
-    return _pubspecFormatException(
-      'Failed to parse pubspec.yaml. Invalid YAML syntax. '
-      'Please check your pubspec.yaml file. Error: $error',
-      stackTrace,
-    );
-  }
-
-  if (yaml is Map<Object?, Object?>) {
-    return _stringKeyedMap(yaml);
-  }
-
-  return _pubspecFormatException(
-    'Expected pubspec.yaml to define a map at the top level.',
-    StackTrace.current,
-  );
-}
-
-Map<String, Object?> _stringKeyedMap(Map<Object?, Object?> source) {
-  return source.map((key, value) {
-    final stringKey = key?.toString();
-    if (stringKey == null) {
-      throw const FormatException('Encountered null key in pubspec.yaml map.');
-    }
-
-    return MapEntry(stringKey, value);
-  });
-}
-
-Never _pubspecFormatException(String message, StackTrace stackTrace) {
-  return Error.throwWithStackTrace(FormatException(message), stackTrace);
 }

--- a/packages/core/lib/src/utils/yaml_utils.dart
+++ b/packages/core/lib/src/utils/yaml_utils.dart
@@ -26,14 +26,18 @@ Map<String, Object?> parseYamlMap(
     );
   }
 
-  if (yamlDoc == null) return {};
+  if (yamlDoc == null) {
+    throw FormatException(
+      'Expected $sourceLabel to define a map at the top level.',
+    );
+  }
   if (yamlDoc is! Map) {
     throw FormatException(
       'Expected $sourceLabel to define a map at the top level.',
     );
   }
 
-  return _deepConvert(yamlDoc) as Map<String, Object?>;
+  return _deepConvertStrictMap(yamlDoc, sourceLabel);
 }
 
 /// Converts YAML string to a `Map<String, Object?>`
@@ -70,6 +74,35 @@ Map<String, Object?> convertYamlToMap(
     if (strict) rethrow;
     return {};
   }
+}
+
+Map<String, Object?> _deepConvertStrictMap(
+  Map<Object?, Object?> value,
+  String sourceLabel,
+) {
+  return Map<String, Object?>.fromEntries(
+    value.entries.map((entry) {
+      final key = entry.key;
+      if (key == null) {
+        throw FormatException('Encountered a null YAML key in $sourceLabel.');
+      }
+
+      return MapEntry(
+        key.toString(),
+        _deepConvertStrict(entry.value, sourceLabel),
+      );
+    }),
+  );
+}
+
+Object? _deepConvertStrict(Object? value, String sourceLabel) {
+  if (value is Map) {
+    return _deepConvertStrictMap(value, sourceLabel);
+  }
+  if (value is List) {
+    return value.map((item) => _deepConvertStrict(item, sourceLabel)).toList();
+  }
+  return value;
 }
 
 /// Recursively converts YAML types (YamlMap, YamlList) to plain Dart types

--- a/packages/core/lib/src/utils/yaml_utils.dart
+++ b/packages/core/lib/src/utils/yaml_utils.dart
@@ -27,15 +27,13 @@ Map<String, Object?> parseYamlMap(
   }
 
   if (yamlDoc == null) return {};
-
-  final converted = _deepConvert(yamlDoc);
-  if (converted is Map<String, Object?>) {
-    return converted;
+  if (yamlDoc is! Map) {
+    throw FormatException(
+      'Expected $sourceLabel to define a map at the top level.',
+    );
   }
 
-  throw FormatException(
-    'Expected $sourceLabel to define a map at the top level.',
-  );
+  return _deepConvert(yamlDoc) as Map<String, Object?>;
 }
 
 /// Converts YAML string to a `Map<String, Object?>`

--- a/packages/core/lib/src/utils/yaml_utils.dart
+++ b/packages/core/lib/src/utils/yaml_utils.dart
@@ -3,6 +3,41 @@ import 'package:yaml/yaml.dart';
 
 final _logger = Logger('YamlUtils');
 
+/// Parses YAML string into a deeply converted `Map<String, Object?>`.
+///
+/// Throws [FormatException] when [yamlString] has invalid syntax or when the
+/// top-level document is not a map. [sourceLabel] is included in error messages
+/// so callers can identify the source file or field.
+Map<String, Object?> parseYamlMap(
+  String yamlString, {
+  String sourceLabel = 'YAML',
+}) {
+  if (yamlString.trim().isEmpty) return {};
+
+  Object? yamlDoc;
+  try {
+    yamlDoc = loadYaml(yamlString);
+  } on YamlException catch (error, stackTrace) {
+    return Error.throwWithStackTrace(
+      FormatException(
+        'Failed to parse $sourceLabel. Invalid YAML syntax. Error: $error',
+      ),
+      stackTrace,
+    );
+  }
+
+  if (yamlDoc == null) return {};
+
+  final converted = _deepConvert(yamlDoc);
+  if (converted is Map<String, Object?>) {
+    return converted;
+  }
+
+  throw FormatException(
+    'Expected $sourceLabel to define a map at the top level.',
+  );
+}
+
 /// Converts YAML string to a `Map<String, Object?>`
 ///
 /// Supports both block-style and flow-style YAML:

--- a/packages/core/test/src/utils/yaml_utils_test.dart
+++ b/packages/core/test/src/utils/yaml_utils_test.dart
@@ -73,6 +73,35 @@ flutter:
         );
       });
 
+      test('throws FormatException for null YAML document', () {
+        expect(
+          () => parseYamlMap('---\n...', sourceLabel: 'pubspec.yaml'),
+          throwsA(
+            isA<FormatException>().having(
+              (error) => error.message,
+              'message',
+              contains('pubspec.yaml'),
+            ),
+          ),
+        );
+      });
+
+      test('throws FormatException for null YAML keys', () {
+        expect(
+          () => parseYamlMap('''
+?
+: value
+''', sourceLabel: 'pubspec.yaml'),
+          throwsA(
+            isA<FormatException>().having(
+              (error) => error.message,
+              'message',
+              allOf(contains('null YAML key'), contains('pubspec.yaml')),
+            ),
+          ),
+        );
+      });
+
       test(
         'throws FormatException containing source label for invalid YAML',
         () {

--- a/packages/core/test/src/utils/yaml_utils_test.dart
+++ b/packages/core/test/src/utils/yaml_utils_test.dart
@@ -4,6 +4,95 @@ import 'package:yaml/yaml.dart';
 
 void main() {
   group('YamlUtils', () {
+    group('parseYamlMap', () {
+      test('returns empty map for empty YAML', () {
+        expect(parseYamlMap(''), isEmpty);
+        expect(parseYamlMap('   \n\t  '), isEmpty);
+      });
+
+      test('parses valid top-level map', () {
+        const yaml = '''
+name: test_app
+version: 1.0.0
+publish_to: none
+''';
+
+        expect(parseYamlMap(yaml), {
+          'name': 'test_app',
+          'version': '1.0.0',
+          'publish_to': 'none',
+        });
+      });
+
+      test('converts nested maps and lists into plain Dart collections', () {
+        const yaml = '''
+dependencies:
+  flutter:
+    sdk: flutter
+flutter:
+  assets:
+    - .superdeck/
+    - .superdeck/assets/
+''';
+
+        final result = parseYamlMap(yaml);
+        final dependencies = result['dependencies'];
+        final flutterDependency = (dependencies as Map)['flutter'];
+        final flutter = result['flutter'];
+        final assets = (flutter as Map)['assets'];
+
+        expect(dependencies, isA<Map>());
+        expect(dependencies, isNot(isA<YamlMap>()));
+        expect(flutterDependency, isA<Map>());
+        expect(flutterDependency, isNot(isA<YamlMap>()));
+        expect(assets, isA<List>());
+        expect(assets, isNot(isA<YamlList>()));
+        expect(assets, ['.superdeck/', '.superdeck/assets/']);
+      });
+
+      test('throws FormatException for top-level scalar', () {
+        expect(
+          () => parseYamlMap('not a map', sourceLabel: 'pubspec.yaml'),
+          throwsA(
+            isA<FormatException>().having(
+              (error) => error.message,
+              'message',
+              contains('pubspec.yaml'),
+            ),
+          ),
+        );
+      });
+
+      test('throws FormatException for top-level list', () {
+        expect(
+          () => parseYamlMap('''
+- first
+- second
+''', sourceLabel: 'pubspec.yaml'),
+          throwsA(isA<FormatException>()),
+        );
+      });
+
+      test(
+        'throws FormatException containing source label for invalid YAML',
+        () {
+          expect(
+            () => parseYamlMap('name: [broken', sourceLabel: 'pubspec.yaml'),
+            throwsA(
+              isA<FormatException>().having(
+                (error) => error.message,
+                'message',
+                allOf(
+                  contains('pubspec.yaml'),
+                  contains('Invalid YAML syntax'),
+                ),
+              ),
+            ),
+          );
+        },
+      );
+    });
+
     group('convertYamlToMap', () {
       group('valid YAML', () {
         test('parses simple key-value pairs', () {


### PR DESCRIPTION
## Summary
- Add strict `parseYamlMap` to `superdeck_core` for source-labeled YAML map parsing.
- Update CLI setup and pubspec asset paths to use the shared helper.
- Remove duplicated CLI YAML map loaders and recursive normalizers while preserving strict validation.

## Validation
- `cd packages/core && fvm dart test test/src/utils/yaml_utils_test.dart`
- `cd packages/cli && fvm dart test test/src/utils/update_pubspec_test.dart`
- `cd packages/cli && fvm dart test test/src/commands/setup_command_test.dart --plain-name "SetupCommand adds default dependencies when missing"`
- `cd packages/cli && fvm dart test test/src/commands/setup_command_test.dart --plain-name "SetupCommand preserves an existing path-based superdeck dependency"`
- `cd packages/cli && fvm dart test test/src/commands/setup_command_test.dart --plain-name "SetupCommand preserves an existing git-based superdeck_cli dev dependency"`
- `fvm flutter pub run melos run analyze:dart --no-select`
- `git diff --check`

## Notes
- `melos run test --no-select` was attempted and still fails for existing out-of-scope issues: CLI setup asset resolution via `Isolate.resolvePackageUriSync`, and demo PDF dependency mismatches on `release/next`.