### PR TITLE
fix(ci): remove fvm use --force from firebase-hosting workflows

### DIFF
--- a/.github/workflows/firebase-hosting-merge.yml
+++ b/.github/workflows/firebase-hosting-merge.yml
@@ -30,8 +30,6 @@ jobs:
         run: |
           curl -fsSL https://fvm.app/install.sh | bash
           echo "/home/runner/fvm/bin" >> $GITHUB_PATH
-          export PATH="/home/runner/fvm/bin:$PATH"
-          fvm use --force
 
       - uses: kuhnroyal/flutter-fvm-config-action@v2
         id: fvm-config-action

--- a/.github/workflows/firebase-hosting-pull-request.yml
+++ b/.github/workflows/firebase-hosting-pull-request.yml
@@ -29,8 +29,6 @@ jobs:
         run: |
           curl -fsSL https://fvm.app/install.sh | bash
           echo "/home/runner/fvm/bin" >> $GITHUB_PATH
-          export PATH="/home/runner/fvm/bin:$PATH"
-          fvm use --force
 
       - uses: kuhnroyal/flutter-fvm-config-action@v2
         id: fvm-config-action


### PR DESCRIPTION
## Summary
Drops the `fvm use --force` line from both firebase-hosting workflows (`firebase-hosting-merge.yml`, `firebase-hosting-pull-request.yml`).

## Why
The `build_and_preview` job has been failing on every PR from the main repo, while the `test.yml` workflows (Test, Integration Tests, Web Smoke) pass — same `.fvmrc`, same `kuhnroyal/flutter-fvm-config-action@v2`, same `subosito/flutter-action@v2`. The only meaningful difference is the firebase-hosting workflows' extra `fvm use --force` line in the Install FVM step.

`fvm use --force` pre-creates `.fvm/flutter_sdk` pointing at FVM's own checkout, which lacks a proper `bin/internal/engine.stamp`. The later `ln -sfn "\$FLUTTER_ROOT" .fvm/flutter_sdk` apparently does not fully replace that pre-existing symlink, so `melos bootstrap` ends up calling FVM's Flutter for `packages/superdeck`. Pub then fails resolving engine info:

```
Failed to download https://storage.googleapis.com/flutter_infra_release/flutter//engine_stamp.json
Exception: 404
```

(Double slash = empty version segment.) Other packages succeed because they are pure Dart and do not trigger engine resolution.

Aligning these workflows with `test.yml` (no `fvm use --force`) fixes the build.

## Test plan
- [ ] `build_and_preview` succeeds on this PR
- [ ] Bootstrap completes for `packages/superdeck` without 404 on engine_stamp.json