### PR TITLE
chore: update mix to 2.0.3 and remix to 0.2.0

### DIFF
--- a/.fvmrc
+++ b/.fvmrc
@@ -1,3 +1,3 @@
 {
-  "flutter": "stable"
+  "flutter": "3.41.9"
 }

--- a/.fvmrc
+++ b/.fvmrc
@@ -1,3 +1,3 @@
 {
-  "flutter": "3.41.9"
+  "flutter": "stable"
 }

--- a/demo/pubspec.yaml
+++ b/demo/pubspec.yaml
@@ -10,12 +10,12 @@ dependencies:
     sdk: flutter
   google_fonts: ^6.3.2
   mesh: ^0.4.3
-  mix: ^2.0.0-rc.0
+  mix: ^2.0.2
   superdeck_core: ^1.0.0
   superdeck: ^1.0.0
   signals_flutter: ^6.0.4
   naked_ui: ^0.2.0-beta.7
-  remix: ^0.1.0-beta.1
+  remix: ^0.2.0
 dev_dependencies:
   flutter_test:
     sdk: flutter

--- a/demo/pubspec.yaml
+++ b/demo/pubspec.yaml
@@ -10,7 +10,7 @@ dependencies:
     sdk: flutter
   google_fonts: ^6.3.2
   mesh: ^0.4.3
-  mix: ^2.0.2
+  mix: ^2.0.3
   superdeck_core: ^1.0.0
   superdeck: ^1.0.0
   signals_flutter: ^6.0.4

--- a/melos.yaml
+++ b/melos.yaml
@@ -12,7 +12,7 @@ command:
       flutter: ">=3.38.1"
     dependencies:
       collection: ^1.18.0
-      mix: ^2.0.0-rc.0
+      mix: ^2.0.2
       ack: 1.0.0-beta.9
   # publish:
     # hooks:

--- a/melos.yaml
+++ b/melos.yaml
@@ -12,7 +12,7 @@ command:
       flutter: ">=3.38.1"
     dependencies:
       collection: ^1.18.0
-      mix: ^2.0.2
+      mix: ^2.0.3
       ack: 1.0.0-beta.9
   # publish:
     # hooks:

--- a/packages/superdeck/lib/src/ui/widgets/button.dart
+++ b/packages/superdeck/lib/src/ui/widgets/button.dart
@@ -20,7 +20,7 @@ class SDButton extends StatelessWidget {
       onPressed: onPressed,
       style: _style,
       label: label,
-      icon: icon,
+      leadingIcon: icon,
     );
   }
 

--- a/packages/superdeck/pubspec.yaml
+++ b/packages/superdeck/pubspec.yaml
@@ -21,8 +21,8 @@ dependencies:
   scrollable_positioned_list: ^0.3.8
   go_router: ^14.2.7
   path_provider: ^2.1.4
-  mix: ^2.0.0-rc.0
-  remix: ^0.1.0-beta.2
+  mix: ^2.0.2
+  remix: ^0.2.0
   flutter_markdown_plus: ^1.0.5
   superdeck_core: ^1.0.0
   markdown: ^7.3.0

--- a/packages/superdeck/pubspec.yaml
+++ b/packages/superdeck/pubspec.yaml
@@ -21,7 +21,7 @@ dependencies:
   scrollable_positioned_list: ^0.3.8
   go_router: ^14.2.7
   path_provider: ^2.1.4
-  mix: ^2.0.2
+  mix: ^2.0.3
   remix: ^0.2.0
   flutter_markdown_plus: ^1.0.5
   superdeck_core: ^1.0.0


### PR DESCRIPTION
## Summary

- Bumps `mix` to `^2.0.3` and `remix` to `^0.2.0` in `packages/superdeck`, `demo`, and the `melos.yaml` shared-dependency pin. `mix` 2.0.3 removes `TextDecorationRef` so it builds against newer Flutter SDKs where `TextDecoration` is `final` (mix#913).
- Adapts `SDButton` to remix 0.2.0's `leadingIcon`/`trailingIcon` API (renamed from `icon`).
- `.fvmrc` continues to track the `stable` channel — no Flutter pin needed with mix 2.0.3.

## Impacted packages

- `packages/superdeck`
- `demo`
- workspace pin via `melos.yaml`

## Test plan

- [x] `melos bootstrap`
- [x] `dart analyze` (clean)
- [x] `superdeck` test suite (551 passing)
- [x] `flutter build web --release` of the demo on Flutter 3.44.0 stable

🤖 Generated with [Claude Code](https://claude.com/claude-code)