### PR TITLE
chore: apply dart format and dcm fix across packages

### DIFF
--- a/packages/builder/test/src/build/deck_builder_watch_test.dart
+++ b/packages/builder/test/src/build/deck_builder_watch_test.dart
@@ -101,10 +101,7 @@ Future<BuildEvent> _nextEvent(StreamIterator<BuildEvent> iterator) async {
   return iterator.current;
 }
 
-Future<void> _modifySlidesFile(
-  DeckWorkspace workspace,
-  String markdown,
-) async {
+Future<void> _modifySlidesFile(DeckWorkspace workspace, String markdown) async {
   await Future<void>.delayed(const Duration(milliseconds: 100));
   await workspace.slidesFile.writeAsString(markdown);
 }

--- a/packages/cli/lib/runner.dart
+++ b/packages/cli/lib/runner.dart
@@ -56,12 +56,12 @@ class SuperDeckRunner extends CommandRunner<int> {
       }
 
       if (argResults['verbose'] == true) {
-        _logger.level = Level.verbose;
+        _logger.level = .verbose;
         _logger.detail('Verbose logging enabled');
       }
 
       if (argResults['quiet'] == true) {
-        _logger.level = Level.error;
+        _logger.level = .error;
       }
 
       final exitCode = await runCommand(argResults);

--- a/packages/cli/lib/src/commands/build_command.dart
+++ b/packages/cli/lib/src/commands/build_command.dart
@@ -91,9 +91,9 @@ class BuildCommand extends SuperDeckCommand {
       logger.err('File system error: ${e.message}');
       logger.err('Path: ${e.path ?? 'Unknown'}');
       await store.saveBuildStatus(
-        phase: DeckBuildPhase.failure,
+        phase: .failure,
         error: e,
-        stackTrace: StackTrace.current,
+        stackTrace: .current,
       );
 
       return false;
@@ -101,9 +101,9 @@ class BuildCommand extends SuperDeckCommand {
       progress.fail('Format error');
       logger.err(e.message);
       await store.saveBuildStatus(
-        phase: DeckBuildPhase.failure,
+        phase: .failure,
         error: e,
-        stackTrace: StackTrace.current,
+        stackTrace: .current,
       );
 
       return false;
@@ -111,7 +111,7 @@ class BuildCommand extends SuperDeckCommand {
       progress.fail('Build failed');
       _logBuildFailure(e, stackTrace);
       await store.saveBuildStatus(
-        phase: DeckBuildPhase.failure,
+        phase: .failure,
         error: e,
         stackTrace: stackTrace,
       );
@@ -198,9 +198,7 @@ class BuildCommand extends SuperDeckCommand {
                     exit(ExitCode.success.code);
                   default:
                     logger.warn('Unknown command: "$command"');
-                    logger.info(
-                      'Available commands: r (rebuild), q (quit)',
-                    );
+                    logger.info('Available commands: r (rebuild), q (quit)');
                 }
               });
 
@@ -229,7 +227,7 @@ class BuildCommand extends SuperDeckCommand {
       logger.err('Build failed before the deck could be generated.');
       _logBuildFailure(e, stackTrace);
       await store?.saveBuildStatus(
-        phase: DeckBuildPhase.failure,
+        phase: .failure,
         error: e,
         stackTrace: stackTrace,
       );

--- a/packages/cli/lib/src/commands/setup/setup_support.dart
+++ b/packages/cli/lib/src/commands/setup/setup_support.dart
@@ -4,7 +4,7 @@ import 'package:path/path.dart' as path;
 import 'package:superdeck_core/superdeck_core.dart';
 import 'package:yaml_writer/yaml_writer.dart';
 
-const _debugEntitlements = <String, bool>{
+const _debugEntitlements = {
   'com.apple.security.app-sandbox': false,
   'com.apple.security.cs.allow-jit': true,
   'com.apple.security.network.server': true,
@@ -13,7 +13,7 @@ const _debugEntitlements = <String, bool>{
   'com.apple.security.files.user-selected.read-write': true,
 };
 
-const _releaseEntitlements = <String, bool>{
+const _releaseEntitlements = {
   'com.apple.security.app-sandbox': true,
   'com.apple.security.files.user-selected.read-write': true,
   'com.apple.security.network.client': true,
@@ -74,6 +74,7 @@ String patchSetupPubspec(String pubspecContents) {
 
   flutter['assets'] = assets;
   final updated = Map.of(pubspec)..['flutter'] = flutter;
+
   return YamlWriter(allowUnquotedStrings: true).write(updated);
 }
 

--- a/packages/cli/lib/src/commands/setup_command.dart
+++ b/packages/cli/lib/src/commands/setup_command.dart
@@ -13,12 +13,6 @@ class SetupCommand extends SuperDeckCommand {
     : _projectDir = projectDir;
 
   @override
-  String get description => 'Configure the current Flutter app for SuperDeck';
-
-  @override
-  String get name => 'setup';
-
-  @override
   Future<int> run() async {
     final rest = argResults?.rest ?? const <String>[];
     if (rest.isNotEmpty) {
@@ -37,12 +31,14 @@ class SetupCommand extends SuperDeckCommand {
       await applySetup(projectDir);
     } on FormatException catch (error) {
       logger.err(error.message);
+
       return ExitCode.data.code;
     } on FileSystemException catch (error) {
       logger.err(error.message);
       if (error.path != null) {
         logger.err('Path: ${error.path}');
       }
+
       return ExitCode.ioError.code;
     }
 
@@ -58,4 +54,10 @@ class SetupCommand extends SuperDeckCommand {
 
     return ExitCode.success.code;
   }
+
+  @override
+  String get description => 'Configure the current Flutter app for SuperDeck';
+
+  @override
+  String get name => 'setup';
 }

--- a/packages/cli/lib/src/utils/logger.dart
+++ b/packages/cli/lib/src/utils/logger.dart
@@ -1,7 +1,7 @@
 import 'package:mason_logger/mason_logger.dart';
 import 'package:superdeck_builder/superdeck_builder.dart';
 
-final logger = Logger(theme: LogTheme(), level: Level.info);
+final logger = Logger(theme: LogTheme(), level: .info);
 
 extension LoggerX on Logger {
   void formatError(DeckFormatException exception) {

--- a/packages/cli/test/integration/cli_workflow_test.dart
+++ b/packages/cli/test/integration/cli_workflow_test.dart
@@ -31,10 +31,18 @@ void main() {
         expect(await runner.run(['setup']), ExitCode.success.code);
 
         final pubspec = await _read(projectDir, 'pubspec.yaml');
-        final entitlements =
-            await _read(projectDir, 'macos/Runner/DebugProfile.entitlements');
+        final entitlements = await _read(
+          projectDir,
+          'macos/Runner/DebugProfile.entitlements',
+        );
         expect(_count(pubspec, '.superdeck/'), 1);
-        expect(_count(entitlements, 'com.apple.security.files.user-selected.read-write'), 1);
+        expect(
+          _count(
+            entitlements,
+            'com.apple.security.files.user-selected.read-write',
+          ),
+          1,
+        );
       });
     });
   });
@@ -73,7 +81,8 @@ Future<void> _expectBuild(Directory dir) async {
     workspace.buildStatusJson.existsSync(),
   ], everyElement(isTrue));
   final deck = jsonDecode(await workspace.deckJson.readAsString()) as List;
-  final status = jsonDecode(await workspace.buildStatusJson.readAsString()) as Map;
+  final status =
+      jsonDecode(await workspace.buildStatusJson.readAsString()) as Map;
   expect(deck, hasLength(2));
   expect(status['status'], 'success');
   expect(status['slideCount'], 2);
@@ -99,6 +108,7 @@ int _count(String contents, String pattern) =>
 const _entitlements =
     '<plist version="1.0"><dict><key>com.apple.security.app-sandbox</key>'
     '<true/></dict></plist>';
-const _slides = '---\ntitle: Cover\n---\n# SuperDeck Workflow\n\n'
+const _slides =
+    '---\ntitle: Cover\n---\n# SuperDeck Workflow\n\n'
     'A complete CLI build.\n\n---\ntitle: Layout\n---\n@section\n@block\n\n'
     '## Agenda\n\n- Setup\n- Build\n- Load\n';

--- a/packages/cli/test/src/commands/setup_command_test.dart
+++ b/packages/cli/test/src/commands/setup_command_test.dart
@@ -20,45 +20,51 @@ void main() {
       runner = createTestRunner(SetupCommand(projectDir: tempDir.path));
     });
 
-    test('configures placeholders, pubspec assets, and macOS entitlements', () async {
-      await _createMinimalFlutterApp(tempDir, includeMacos: true);
+    test(
+      'configures placeholders, pubspec assets, and macOS entitlements',
+      () async {
+        await _createMinimalFlutterApp(tempDir, includeMacos: true);
 
-      final mainFile = File(path.join(tempDir.path, 'lib', 'main.dart'));
-      await mainFile.create(recursive: true);
-      await mainFile.writeAsString('void main() => print("keep");\n');
+        final mainFile = File(path.join(tempDir.path, 'lib', 'main.dart'));
+        await mainFile.create(recursive: true);
+        await mainFile.writeAsString('void main() => print("keep");\n');
 
-      final slidesFile = File(path.join(tempDir.path, 'slides.md'));
-      await slidesFile.writeAsString('# Keep me');
+        final slidesFile = File(path.join(tempDir.path, 'slides.md'));
+        await slidesFile.writeAsString('# Keep me');
 
-      final result = await runner.run(['setup']);
+        final result = await runner.run(['setup']);
 
-      expect(result, ExitCode.success.code);
-      expect(await mainFile.readAsString(), 'void main() => print("keep");\n');
-      expect(await slidesFile.readAsString(), '# Keep me');
-      expect(
-        await File(path.join(tempDir.path, 'pubspec.yaml')).readAsString(),
-        contains('.superdeck/'),
-      );
-      expect(
-        Directory(path.join(tempDir.path, '.superdeck')).existsSync(),
-        isTrue,
-      );
-      expect(
-        await File(
-          path.join(
-            tempDir.path,
-            'macos',
-            'Runner',
-            'DebugProfile.entitlements',
+        expect(result, ExitCode.success.code);
+        expect(
+          await mainFile.readAsString(),
+          'void main() => print("keep");\n',
+        );
+        expect(await slidesFile.readAsString(), '# Keep me');
+        expect(
+          await File(path.join(tempDir.path, 'pubspec.yaml')).readAsString(),
+          contains('.superdeck/'),
+        );
+        expect(
+          Directory(path.join(tempDir.path, '.superdeck')).existsSync(),
+          isTrue,
+        );
+        expect(
+          await File(
+            path.join(
+              tempDir.path,
+              'macos',
+              'Runner',
+              'DebugProfile.entitlements',
+            ),
+          ).readAsString(),
+          allOf(
+            contains('com.apple.security.files.user-selected.read-write'),
+            contains('com.apple.security.files.downloads.read-write'),
+            contains('<false/>'),
           ),
-        ).readAsString(),
-        allOf(
-          contains('com.apple.security.files.user-selected.read-write'),
-          contains('com.apple.security.files.downloads.read-write'),
-          contains('<false/>'),
-        ),
-      );
-    });
+        );
+      },
+    );
 
     test('adds .superdeck asset entries to pubspec flutter.assets', () {
       final patched = patchSetupPubspec(_fakePubspec('existing_app'));
@@ -148,7 +154,6 @@ void main() {
 
       expect(result, ExitCode.ioError.code);
     });
-
   });
 }
 

--- a/packages/cli/test/src/runner_test.dart
+++ b/packages/cli/test/src/runner_test.dart
@@ -81,10 +81,7 @@ void main() {
           exitCode,
           anyOf(equals(ExitCode.success.code), equals(ExitCode.software.code)),
         );
-        expect(
-          mockLogger.detailMessages,
-          contains('Verbose logging enabled'),
-        );
+        expect(mockLogger.detailMessages, contains('Verbose logging enabled'));
       });
     });
   });
@@ -114,8 +111,9 @@ flutter:
   final runnerDir = Directory(path.join(projectDir.path, 'macos', 'Runner'));
   await runnerDir.create(recursive: true);
   for (final name in ['DebugProfile.entitlements', 'Release.entitlements']) {
-    await File(path.join(runnerDir.path, name))
-        .writeAsString('<plist version="1.0"><dict></dict></plist>');
+    await File(
+      path.join(runnerDir.path, name),
+    ).writeAsString('<plist version="1.0"><dict></dict></plist>');
   }
 }
 

--- a/packages/core/lib/src/deck/deck_workspace.dart
+++ b/packages/core/lib/src/deck/deck_workspace.dart
@@ -12,13 +12,10 @@ final class DeckWorkspace with DeckWorkspaceMappable {
   final String slidesPath;
   final String outputDir;
 
-  DeckWorkspace({
-    String? projectDir,
-    String? slidesPath,
-    String? outputDir,
-  }) : projectDir = projectDir ?? '.',
-       slidesPath = slidesPath ?? 'slides.md',
-       outputDir = outputDir ?? '.superdeck' {
+  DeckWorkspace({String? projectDir, String? slidesPath, String? outputDir})
+    : projectDir = projectDir ?? '.',
+      slidesPath = slidesPath ?? 'slides.md',
+      outputDir = outputDir ?? '.superdeck' {
     _validatePath('slidesPath', this.slidesPath);
     _validatePath('outputDir', this.outputDir);
   }

--- a/packages/core/test/src/deck/block_model_test.dart
+++ b/packages/core/test/src/deck/block_model_test.dart
@@ -296,10 +296,7 @@ void main() {
         });
 
         test('uses explicit align when set', () {
-          final block = ContentBlock(
-            'Content',
-            align: ContentAlignment.center,
-          );
+          final block = ContentBlock('Content', align: ContentAlignment.center);
 
           expect(block.resolvedAlign, ContentAlignment.center);
         });

--- a/packages/core/test/src/deck/deck_loader_events_test.dart
+++ b/packages/core/test/src/deck/deck_loader_events_test.dart
@@ -58,10 +58,7 @@ void main() {
 
     test('exposes the provided error payload', () {
       final error = StateError('missing slides.md');
-      final event = SlidesErrorEvent(
-        'Failed to load slides',
-        error: error,
-      );
+      final event = SlidesErrorEvent('Failed to load slides', error: error);
 
       expect(event.error, same(error));
     });

--- a/packages/superdeck/lib/src/deck/deck_session_state.dart
+++ b/packages/superdeck/lib/src/deck/deck_session_state.dart
@@ -16,7 +16,8 @@ final class DeckSessionState {
   final _isBuildActive = signal<bool>(false);
   final _buildFailure = signal<DeckBuildError?>(null);
 
-  DeckSessionState({required DeckLoader deckLoader}) : _deckLoader = deckLoader {
+  DeckSessionState({required DeckLoader deckLoader})
+    : _deckLoader = deckLoader {
     _subscription = _deckLoader.load().listen(
       _handleEvent,
       onError: (Object error, StackTrace stackTrace) {

--- a/packages/superdeck/lib/src/ui/app_shell.dart
+++ b/packages/superdeck/lib/src/ui/app_shell.dart
@@ -160,10 +160,7 @@ class _SplitViewState extends State<SplitView>
         return;
       }
 
-      deckController.presentation.generateThumbnails(
-        context,
-        currentSlides,
-      );
+      deckController.presentation.generateThumbnails(context, currentSlides);
       _lastThumbnailWarmupSignature = currentSignature;
       if (_pendingThumbnailWarmupSignature == currentSignature) {
         _pendingThumbnailWarmupSignature = null;

--- a/packages/superdeck/test/src/deck/deck_controller_builder_test.dart
+++ b/packages/superdeck/test/src/deck/deck_controller_builder_test.dart
@@ -9,50 +9,49 @@ import '../../helpers/mock_deck_loader.dart';
 void main() {
   group('DeckControllerBuilder', () {
     // This test runs first because it does not corrupt widget tree state.
-    testWidgets(
-      'options change propagates without assertion error',
-      (tester) async {
-        final loader = MockDeckLoader();
+    testWidgets('options change propagates without assertion error', (
+      tester,
+    ) async {
+      final loader = MockDeckLoader();
 
-        // Intercept FlutterErrors to check for assertion errors
-        final loaderAssertErrors = <FlutterErrorDetails>[];
-        final originalHandler = FlutterError.onError;
-        FlutterError.onError = (details) {
-          final ex = details.exception;
-          if (ex is AssertionError &&
-              ex.message.toString().contains('must not change after mount')) {
-            loaderAssertErrors.add(details);
-          }
-          // Suppress all errors (overflow, etc.)
-        };
+      // Intercept FlutterErrors to check for assertion errors
+      final loaderAssertErrors = <FlutterErrorDetails>[];
+      final originalHandler = FlutterError.onError;
+      FlutterError.onError = (details) {
+        final ex = details.exception;
+        if (ex is AssertionError &&
+            ex.message.toString().contains('must not change after mount')) {
+          loaderAssertErrors.add(details);
+        }
+        // Suppress all errors (overflow, etc.)
+      };
 
-        await tester.pumpWidget(
-          _TestApp(deckLoader: loader, options: DeckOptions()),
-        );
-        await tester.pump(const Duration(milliseconds: 50));
+      await tester.pumpWidget(
+        _TestApp(deckLoader: loader, options: DeckOptions()),
+      );
+      await tester.pump(const Duration(milliseconds: 50));
 
-        // Update with new options — should not fire the loader assert
-        await tester.pumpWidget(
-          _TestApp(deckLoader: loader, options: DeckOptions(debug: true)),
-        );
-        await tester.pump(const Duration(milliseconds: 50));
+      // Update with new options — should not fire the loader assert
+      await tester.pumpWidget(
+        _TestApp(deckLoader: loader, options: DeckOptions(debug: true)),
+      );
+      await tester.pump(const Duration(milliseconds: 50));
 
-        // Restore handler before any assertions
-        FlutterError.onError = originalHandler;
+      // Restore handler before any assertions
+      FlutterError.onError = originalHandler;
 
-        // Drain any queued test framework exceptions
-        while (tester.takeException() != null) {}
+      // Drain any queued test framework exceptions
+      while (tester.takeException() != null) {}
 
-        // No loader-change assertion errors should have been captured
-        expect(
-          loaderAssertErrors,
-          isEmpty,
-          reason: 'Changing options should not fire the deckLoader assert',
-        );
+      // No loader-change assertion errors should have been captured
+      expect(
+        loaderAssertErrors,
+        isEmpty,
+        reason: 'Changing options should not fire the deckLoader assert',
+      );
 
-        await loader.dispose();
-      },
-    );
+      await loader.dispose();
+    });
 
     // This test intentionally corrupts the widget tree, so it runs last.
     testWidgets('assert fires when deckLoader changes', (tester) async {

--- a/packages/superdeck/test/src/deck/loaders/deck_controller_file_loader_test.dart
+++ b/packages/superdeck/test/src/deck/loaders/deck_controller_file_loader_test.dart
@@ -69,7 +69,9 @@ void main() {
         );
 
         await _waitUntil(
-          () => !controller.session.isLoading.value && !controller.session.hasFatalError.value,
+          () =>
+              !controller.session.isLoading.value &&
+              !controller.session.hasFatalError.value,
         );
 
         expect(controller.session.isLoading.value, isFalse);
@@ -93,7 +95,9 @@ void main() {
         );
 
         await _waitUntil(
-          () => !controller.session.isLoading.value && !controller.session.hasFatalError.value,
+          () =>
+              !controller.session.isLoading.value &&
+              !controller.session.hasFatalError.value,
         );
 
         expect(controller.session.isLoading.value, isFalse);
@@ -133,7 +137,9 @@ void main() {
       createController();
 
       await _waitUntil(
-        () => !controller.session.isLoading.value && controller.session.hasFatalError.value,
+        () =>
+            !controller.session.isLoading.value &&
+            controller.session.hasFatalError.value,
       );
 
       expect(controller.session.isLoading.value, isFalse);


### PR DESCRIPTION
## Intent
Apply the repo's formatting/lint tooling across all packages to normalize the codebase. No behavioral changes.

## Changes
- **`dart format`** — whitespace / line-wrapping normalization (test + lib files)
- **`dcm fix`** (safe fixes only, no `--unsafe`):
  - dot-shorthand for enum/static refs in `cli` (`Level.verbose` → `.verbose`, `DeckBuildPhase.failure` → `.failure`, `StackTrace.current` → `.current`)
  - removed redundant type annotations on `const` maps
  - newline-before-return
  - member ordering (`setup_command.dart`)
- **`dart fix --apply`** — no changes required

## Impacted packages
- `core`, `cli`, `superdeck` (lib + test)
- `builder` (test file formatting only)

## Commands run
```
melos exec -- dart fix --apply .
melos exec --depends-on=dart_code_metrics_presets -- dcm fix .
melos exec -- dart format .
```

## Testing
- `dart analyze` → **No issues found** (all 5 packages)
- `dart format` is **idempotent** (re-run reports 0 changed)
- Full CI green on this commit (unit, integration, web-smoke, Firebase preview)

## Note for reviewer
The dot-shorthand rewrites are net-new style for this codebase, from the DCM preset's `prefer-dot-shorthand` rule (analyze-clean at the Dart 3.10 floor). If undesired, disable the rule in DCM config rather than reverting code here.

> The Flutter 3.44.2 upgrade was split out — it surfaced a `RenderBox was not laid out` layout regression on the asset-heavy slide (caught by web-smoke). It will be handled in a dedicated PR.